### PR TITLE
Root-cause blog cron timeout + close CI/lint gaps

### DIFF
--- a/.claude/skills/blog-backfill/scripts/check-crosspost-queue.sh
+++ b/.claude/skills/blog-backfill/scripts/check-crosspost-queue.sh
@@ -47,8 +47,6 @@ processed=0
 for i in $(seq 0 $((count - 1))); do
   entry=$(echo "$queue" | jq ".[$i]")
   slug=$(echo "$entry" | jq -r '.slug')
-  title=$(echo "$entry" | jq -r '.title // .slug')
-  canonical=$(echo "$entry" | jq -r '.canonical_url')
 
   echo "" >&2
   echo "=== $slug ===" >&2

--- a/.claude/skills/blog-backfill/scripts/feedback-sweep.py
+++ b/.claude/skills/blog-backfill/scripts/feedback-sweep.py
@@ -21,7 +21,7 @@ Exit codes:
   1 — fatal IO error (missing file, write failure).
 
 Output:
-  - Appends to /home/jeremy/000-projects/blog/startaitools/.claude/skills/blog-backfill/methodology/feedback.jsonl
+  - Appends to <repo>/.claude/skills/blog-backfill/methodology/feedback.jsonl
   - Writes digest to stdout (caller wires this into email/ntfy)
 """
 
@@ -52,7 +52,7 @@ TIER2_MAX_LINES = 260
 NAMED_ARTIFACT_WORDS = {
     "pattern", "framework", "methodology", "principle", "guard", "guards",
     "rubric", "playbook", "contract", "cascade", "dual-layer", "three-act",
-    "anti-pattern", "playbook", "checklist", "protocol",
+    "anti-pattern", "checklist", "protocol",
 }
 # Words suggesting genuine narrative drama (Tier 3 NAR floor)
 DRAMA_WORDS = {

--- a/.claude/skills/blog-backfill/scripts/post-to-devto.sh
+++ b/.claude/skills/blog-backfill/scripts/post-to-devto.sh
@@ -25,7 +25,6 @@ draft_mode=false
 # Parse Astro YAML frontmatter
 title=$(sed -n 's/^title: *"\(.*\)" *$/\1/p' "$input" | head -1)
 description=$(sed -n 's/^description: *"\(.*\)" *$/\1/p' "$input" | head -1)
-date=$(sed -n 's/^date: *"\(.*\)" *$/\1/p' "$input" | head -1)
 # Extract tags as comma-separated, max 4 for Dev.to
 # Dev.to tags: alphanumeric only, no hyphens, max 4
 tags_raw=$(sed -n 's/^tags: *\[\(.*\)\] *$/\1/p' "$input" | head -1)

--- a/.claude/skills/blog-backfill/scripts/post-to-hashnode.sh
+++ b/.claude/skills/blog-backfill/scripts/post-to-hashnode.sh
@@ -45,10 +45,6 @@ fi
 echo "Creating Hashnode draft: $title" >&2
 echo "  Canonical: $canonical_url" >&2
 
-# Escape body for JSON
-escaped_body=$(echo "$body" | jq -Rs '.')
-escaped_title=$(echo "$title" | jq -Rs '.' | sed 's/^"//;s/"$//')
-
 create_draft_query=$(cat <<'GRAPHQL'
 mutation CreateDraft($input: CreateDraftInput!) {
   createDraft(input: $input) {
@@ -62,7 +58,7 @@ GRAPHQL
 )
 
 draft_variables=$(jq -n \
-  --arg title "$escaped_title" \
+  --arg title "$title" \
   --arg content "$body" \
   --arg pubId "$HASHNODE_PUBLICATION_ID" \
   --arg canonical "$canonical_url" \
@@ -90,6 +86,16 @@ draft_response=$(curl -s -w "\n%{http_code}" \
 
 http_code=$(echo "$draft_response" | tail -1)
 draft_body=$(echo "$draft_response" | sed '$d')
+
+# Detect API host redirect — observed 2026-05-27, every draft creation returns
+# 301 from gql.hashnode.com via Cloudflare. Skip the platform with a clear log
+# message instead of failing the cross-post queue. Re-enable after investigating
+# the new endpoint. Tracked via bead startaitools-6jf side-bug.
+if [[ "$http_code" == "301" ]] || [[ "$http_code" == "302" ]]; then
+  echo "  SKIP: Hashnode GraphQL endpoint returned HTTP $http_code (likely API host moved)" >&2
+  echo "  Re-enable post-to-hashnode.sh after investigating new endpoint URL." >&2
+  exit 0
+fi
 
 if [[ "$http_code" -lt 200 ]] || [[ "$http_code" -ge 300 ]]; then
   echo "  ERROR creating draft: HTTP $http_code" >&2

--- a/.claude/skills/blog-backfill/scripts/post-to-hashnode.sh
+++ b/.claude/skills/blog-backfill/scripts/post-to-hashnode.sh
@@ -88,13 +88,14 @@ http_code=$(echo "$draft_response" | tail -1)
 draft_body=$(echo "$draft_response" | sed '$d')
 
 # Detect API host redirect — observed 2026-05-27, every draft creation returns
-# 301 from gql.hashnode.com via Cloudflare. Skip the platform with a clear log
-# message instead of failing the cross-post queue. Re-enable after investigating
-# the new endpoint. Tracked via bead startaitools-6jf side-bug.
+# 301 from gql.hashnode.com via Cloudflare. Exit non-zero so the cross-post
+# queue manager registers this as a failure and keeps the entry recoverable,
+# rather than silently marking it "published" with an empty URL (which would
+# remove it from the queue permanently). Tracked via bead startaitools-6jf.
 if [[ "$http_code" == "301" ]] || [[ "$http_code" == "302" ]]; then
-  echo "  SKIP: Hashnode GraphQL endpoint returned HTTP $http_code (likely API host moved)" >&2
-  echo "  Re-enable post-to-hashnode.sh after investigating new endpoint URL." >&2
-  exit 0
+  echo "ENDPOINT_MOVED: Hashnode GraphQL returned HTTP $http_code from gql.hashnode.com" >&2
+  echo "Investigate new endpoint URL before re-running post-to-hashnode.sh." >&2
+  exit 1
 fi
 
 if [[ "$http_code" -lt 200 ]] || [[ "$http_code" -ge 300 ]]; then

--- a/.claude/skills/blog-backfill/scripts/post-to-medium.sh
+++ b/.claude/skills/blog-backfill/scripts/post-to-medium.sh
@@ -20,7 +20,6 @@ draft_mode=false
 
 # Parse Astro YAML frontmatter
 title=$(sed -n 's/^title: *"\(.*\)" *$/\1/p' "$input" | head -1)
-description=$(sed -n 's/^description: *"\(.*\)" *$/\1/p' "$input" | head -1)
 tags_raw=$(sed -n 's/^tags: *\[\(.*\)\] *$/\1/p' "$input" | head -1)
 # Medium: strip hyphens, max 5 tags
 tags=$(echo "$tags_raw" | tr ',' '\n' | sed 's/^ *"//;s/" *$//' | sed 's/-//g' | head -5 | jq -R . | jq -s '.')

--- a/.claude/skills/blog-backfill/scripts/post-to-substack.sh
+++ b/.claude/skills/blog-backfill/scripts/post-to-substack.sh
@@ -29,7 +29,10 @@ canonical_url="${CANONICAL_OVERRIDE:-https://startaitools.com/posts/${slug}/}"
 # Extract body (everything after second ---)
 body=$(awk 'BEGIN{c=0} /^---$/{c++; next} c>=2{print}' "$input")
 
-# Strip Hugo/Astro shortcodes ({{< ... >}} and {{% ... %}})
+# Strip Hugo/Astro shortcodes ({{< ... >}} and {{% ... %}}). The brace-pair +
+# delimiter-pair pattern is too complex for bash parameter expansion to handle
+# cleanly; sed regex is the right tool here.
+# shellcheck disable=SC2001 # regex with char classes — not a simple substitution
 clean_body=$(echo "$body" | sed 's/{{[<%] *[^}]* *[>%]}}//g')
 
 # Ensure output directory exists

--- a/.claude/skills/blog-backfill/scripts/scan-session-transcripts.py
+++ b/.claude/skills/blog-backfill/scripts/scan-session-transcripts.py
@@ -13,19 +13,17 @@ use only — do not publish raw scanner output.
 
 Usage:
     python3 scan-session-transcripts.py --start 2026-04-01 --end 2026-04-02
-    python3 scan-session-transcripts.py --start 2026-04-01 --end 2026-04-02 --output /tmp/sessions.txt
+    python3 scan-session-transcripts.py --start 2026-04-01 --end 2026-04-02 \\
+        --output /tmp/sessions.txt
     python3 scan-session-transcripts.py --start 2026-04-01  # single day (end defaults to start+1)
 """
 
 import argparse
 import json
-import os
-import re
 import sys
 from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
-
 
 PROJECTS_DIR = Path.home() / ".claude" / "projects"
 
@@ -114,8 +112,8 @@ def scan_jsonl_file(
     """
     entries = []
     try:
-        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
-            for line_num, line in enumerate(f, 1):
+        with open(filepath, encoding="utf-8", errors="replace") as f:
+            for line in f:
                 line = line.strip()
                 if not line:
                     continue

--- a/.github/workflows/scripts-lint.yml
+++ b/.github/workflows/scripts-lint.yml
@@ -1,0 +1,86 @@
+name: scripts-lint
+
+# Static analysis for blog pipeline scripts + Hugo build sanity. This is the
+# safety net the 2026-05-25/26 silent cron timeout exposed: zero CI on the
+# cron wrappers means a quoting / parameter-expansion / unused-import bug can
+# ship straight to a 7am cron run with no gate. Triggers on every PR and on
+# push to master (in case a hotfix lands directly).
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  shellcheck-blog-scripts:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: shellcheck (cron + skill helpers + verify scripts)
+        run: |
+          shopt -s globstar nullglob
+          files=(
+            scripts/blog/*.sh
+            .claude/skills/blog-*/scripts/*.sh
+            verify_links.sh
+            check_links.sh
+          )
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "no .sh files found — skipping"
+            exit 0
+          fi
+          shellcheck -S style "${files[@]}"
+
+  ruff-blog-scripts:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        run: python3 -m pip install --quiet --upgrade ruff
+
+      - name: ruff check (skill helpers + check-links)
+        run: |
+          shopt -s globstar nullglob
+          files=(
+            .claude/skills/blog-*/scripts/*.py
+            check-links.py
+          )
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "no .py files found — skipping"
+            exit 0
+          fi
+          ruff check "${files[@]}"
+
+  hugo-build-check:
+    name: hugo build (PR only)
+    # Skip on push-to-master since Netlify is the canonical builder there.
+    # PR-only catches front-matter / shortcode breakage before merge.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Hugo (extended, matches netlify.toml)
+        run: |
+          HUGO_VERSION=0.150.0
+          curl -fsSL -o /tmp/hugo.deb \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          sudo dpkg -i /tmp/hugo.deb
+          hugo version
+
+      - name: Build site (with future-dated posts, like netlify.toml)
+        run: hugo --buildFuture --gc -d /tmp/hugo-verify

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,10 @@
+# shellcheck configuration for startaitools.com
+# See https://www.shellcheck.net/wiki/Directive
+
+external-sources=true
+shell=bash
+
+# SC1091: "Not following external source" — fires on `source .env` etc. The
+# referenced files are intentionally untracked (.env holds secrets) so there
+# is nothing for shellcheck to follow. Disabled repo-wide.
+disable=SC1091

--- a/check-links.py
+++ b/check-links.py
@@ -5,15 +5,16 @@ Tests all HTTP/HTTPS links in markdown files
 """
 
 import re
-import sys
 import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from urllib.parse import urlparse
-from concurrent.futures import ThreadPoolExecutor, as_completed
+
 
 def extract_urls_from_file(file_path):
     """Extract all HTTP/HTTPS URLs from a markdown file"""
-    with open(file_path, 'r', encoding='utf-8') as f:
+    with open(file_path, encoding='utf-8') as f:
         content = f.read()
 
     # Find all HTTP/HTTPS URLs - only ASCII characters
@@ -53,7 +54,7 @@ def test_url(url):
         )
         status_code = result.stdout.strip()
         return int(status_code) if status_code.isdigit() else 0
-    except Exception as e:
+    except Exception:
         return 0
 
 def main():
@@ -96,7 +97,7 @@ def main():
                     working_links.append((url, status_code))
                     if i % 50 == 0:
                         print(f"[{i}/{len(all_urls)}] Tested {i} URLs...")
-            except Exception as e:
+            except Exception:
                 broken_links.append((url, 0, all_urls[url]))
                 print(f"[{i}/{len(all_urls)}] ❌ ERROR - {url}")
 
@@ -115,7 +116,7 @@ def main():
         for url, status, files in broken_links:
             print(f"\n❌ {url}")
             print(f"   Status: {status if status else 'TIMEOUT/ERROR'}")
-            print(f"   Found in:")
+            print("   Found in:")
             for file in files:
                 print(f"   - {file}")
 
@@ -134,11 +135,11 @@ def main():
             for url, status, files in broken_links:
                 f.write(f"\n❌ {url}\n")
                 f.write(f"   Status: {status if status else 'TIMEOUT/ERROR'}\n")
-                f.write(f"   Found in:\n")
+                f.write("   Found in:\n")
                 for file in files:
                     f.write(f"   - {file}\n")
 
-    print(f"\nDetailed report saved to: link-check-report.txt")
+    print("\nDetailed report saved to: link-check-report.txt")
 
     return 0 if not broken_links else 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+# Lint config only — startaitools.com is a Hugo site, not a Python project.
+# This file exists so `ruff check` picks up consistent settings for the
+# handful of Python helpers under .claude/skills/blog-*/scripts/ and the
+# repo-level check-links.py.
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP", "B"]

--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -25,18 +25,20 @@ if grep -rl "^date = '$YESTERDAY\|^date = \"$YESTERDAY\|^date: $YESTERDAY" "$POS
 fi
 
 # Run /blog-backfill headlessly. Hard wall-clock ceiling, overridable via env.
-# History (wall time of the claude -p call):
-#   5/13 7m  5/15 13m  5/17 14m  5/19 17m  5/21 13m  5/23 21m  5/24 12m
-#   5/25 + 5/26 TIMEOUT at the prior 1800s ceiling — the skill's wall time
-#   has crept up (more crosspost queue entries, more agents in chain).
-# Bumped to 5400s (90 min) on 2026-05-27 to give ~4x headroom above the
-# worst known-good run. If this is still tight, investigate the skill's
-# Phase 2 wall time directly (bead startaitools-6jf).
-TIMEOUT_SECS="${BLOG_BACKFILL_TIMEOUT:-5400}"
-cd "$BLOG_DIR"
-log "Invoking: claude -p /blog-backfill (timeout ${TIMEOUT_SECS}s)"
+# Default is 1800s (30 min). Wrap claude -p in script(1) so node's CLI sees a
+# pty on stdout and flushes incrementally — without this, all output buffers
+# until SIGKILL, leaving the log opaque on timeout. The pty is the precondition
+# for diagnosing wall-time creep (bead startaitools-6jf).
+TIMEOUT_SECS="${BLOG_BACKFILL_TIMEOUT:-1800}"
+cd "$BLOG_DIR" || { log "FATAL: cd to $BLOG_DIR failed"; exit 1; }
+log "Invoking: claude -p /blog-backfill (timeout ${TIMEOUT_SECS}s, pty-wrapped)"
 T0=$(date +%s)
-if /usr/bin/timeout "$TIMEOUT_SECS" claude -p "/blog-backfill" --dangerously-skip-permissions >> "$LOG" 2>&1; then
+# script(1) gives claude -p a pty so its CLI flushes incrementally instead of
+# buffering until SIGKILL. -e propagates child exit status; -q suppresses the
+# "Script started" framing; -a appends to "$LOG" (the typescript output file
+# is script's trailing positional arg). The >/dev/null sink discards script's
+# own stdout duplicate — the file copy is what we care about.
+if /usr/bin/timeout "$TIMEOUT_SECS" script -e -q -a -c "claude -p '/blog-backfill' --dangerously-skip-permissions" "$LOG" >/dev/null 2>&1; then
   STATUS="OK"
   WALL=$(( $(date +%s) - T0 ))
   log "claude -p exited cleanly after ${WALL}s ($((WALL/60))m $((WALL%60))s)"
@@ -89,16 +91,13 @@ reconcile_repo() {
     RECONCILED="${RECONCILED}${label}: ⚠ ORPHANED on $current — needs manual merge\n"
   fi
 }
-if [ "$STATUS" = "OK" ]; then
-  reconcile_repo "$BLOG_DIR" "startaitools"
-  reconcile_repo "/home/jeremy/000-projects/claude-code-plugins" "tonsofskills"
-fi
-
-# ----- Methodology bookkeeping gate (added 2026-05-16) -----
+# ----- Methodology bookkeeping gate (added 2026-05-16, hoisted 2026-05-28) -----
 # /blog-backfill is required by SKILL.md to write a classifier record (step 3)
 # and an agent_audit addendum (step 8) to decisions.jsonl for each post.
-# Multiple May 2026 runs skipped one or both. Treat missing bookkeeping as a
-# soft failure: STATUS gets a "WITH-WARNING" suffix so the email + ntfy surface it.
+# This check runs BEFORE reconcile_repo: a half-state (post on disk, no
+# methodology record) signals an aborted/timed-out run; we don't want to
+# ff-push such a state to master. The reconcile gate below requires strict
+# STATUS=OK, so missing bookkeeping suppresses the push and surfaces a warning.
 DECISIONS=/home/jeremy/000-projects/blog/startaitools/.claude/skills/blog-backfill/methodology/decisions.jsonl
 if [ "$STATUS" = "OK" ] && [ -n "${NEW_POST_BASENAME:-}" ] && [ "$NEW_POST_BASENAME" != "none" ]; then
   if ! /usr/bin/grep -q "\"date\"[[:space:]]*:[[:space:]]*\"$YESTERDAY\"" "$DECISIONS"; then
@@ -108,6 +107,14 @@ if [ "$STATUS" = "OK" ] && [ -n "${NEW_POST_BASENAME:-}" ] && [ "$NEW_POST_BASEN
     log "WARN: no agent_audit addendum for $NEW_POST_BASENAME — step 8 was skipped"
     STATUS="OK-WITH-WARNING (missing audit addendum)"
   fi
+fi
+
+if [ "$STATUS" = "OK" ]; then
+  reconcile_repo "$BLOG_DIR" "startaitools"
+  reconcile_repo "/home/jeremy/000-projects/claude-code-plugins" "tonsofskills"
+else
+  log "Skipping branch reconciliation — STATUS is '$STATUS' (not strict OK)"
+  RECONCILED="(skipped — STATUS=$STATUS)\n"
 fi
 
 # ----- Methodology index rebuild (mandated by SKILL.md line 173) -----

--- a/scripts/blog/blog-monthly-calibrate.sh
+++ b/scripts/blog/blog-monthly-calibrate.sh
@@ -15,7 +15,7 @@ echo "[$(date -Is)] Starting calibration run for ${YM}" >> "$LOG"
 
 # Run /blog-calibrate via headless Claude Code.
 # `claude -p` runs a one-shot prompt and exits.
-cd /home/jeremy/000-projects/blog/startaitools
+cd /home/jeremy/000-projects/blog/startaitools || { echo "[$(date -Is)] FATAL: cd to blog dir failed" >> "$LOG"; exit 1; }
 if ! /usr/bin/timeout 300 claude -p "/blog-calibrate" --dangerously-skip-permissions > "$REPORT" 2>&1; then
   echo "[$(date -Is)] claude -p exited non-zero — emailing anyway" >> "$LOG"
 fi

--- a/scripts/blog/blog-monthly-retro.sh
+++ b/scripts/blog/blog-monthly-retro.sh
@@ -36,7 +36,7 @@ if [ -f "$RETRO_FILE" ]; then
 fi
 
 # Run /blog-backfill monthly headlessly. 30-min hard timeout.
-cd "$BLOG_DIR"
+cd "$BLOG_DIR" || { log "FATAL: cd to $BLOG_DIR failed"; exit 1; }
 log "Invoking: claude -p /blog-backfill monthly"
 if /usr/bin/timeout 1800 claude -p "/blog-backfill monthly" --dangerously-skip-permissions >> "$LOG" 2>&1; then
   STATUS="OK"

--- a/scripts/blog/blog-social-email.sh
+++ b/scripts/blog/blog-social-email.sh
@@ -24,7 +24,7 @@ sent_count=0
 for x_file in "$X_DIR"/*-backfill-x3.txt; do
   base=$(basename "$x_file" -backfill-x3.txt)
   date_part=$(echo "$base" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}')
-  slug=${base#${date_part}-}
+  slug=${base#"${date_part}-"}
 
   # Already emailed?
   if grep -qxF "$slug" "$SENT" 2>/dev/null; then


### PR DESCRIPTION
## Summary

Two compounding problems surfaced on 2026-05-26/27:

1. **Daily blog-backfill cron silently died** at the 30-min timeout. Logs were 2KB of wrapper framing with nothing in between — node CLIs buffer stdout when piped to a file, so SIGKILL fires before any flush.
2. **Zero CI on the cron wrappers + skill helpers** — 9 shellcheck + 7 ruff findings nobody had ever seen, and a regression in any of these scripts would ship straight to a 7am cron run with no gate.

Three commits, each its own phase for clean review:

- `6469396b` — pty-wrap `claude -p` via `script(1)` so the log captures incremental phase output; revert the 5400s bandage back to 1800s; fix SC2164 unprotected `cd`; hoist methodology bookkeeping check above the ff-push so partial states don't ship.
- `b730c79e` — clear the existing shellcheck (SC2164, SC2295, SC2034, SC2001) + ruff (F401, F841, F541, I001, UP015, B007, B033) backlog across 11 files. Add Hashnode 301 guard so the cross-post queue isn't blocked by a single platform regression.
- `c8f55407` — install `.shellcheckrc` + `pyproject.toml` (ruff-only — this is a Hugo site, not a Python project) + a new `scripts-lint.yml` workflow with three jobs: shellcheck (PR + push), ruff (PR + push), Hugo build (PR only, since Netlify is the canonical builder on master). Pattern lifted from `intentional-cognition-os/.github/workflows/ci.yml::plugin-scripts-lint`.

## Verification

- [x] Local shellcheck clean: `shellcheck -S style scripts/blog/*.sh .claude/skills/blog-*/scripts/*.sh verify_links.sh check_links.sh`
- [x] Local ruff clean: `ruff check .claude/skills/blog-*/scripts/*.py check-links.py`
- [x] pty wrap verified: `script -e -q -a -c "..." LOG` round-trips exit code 7 and captures incremental output line-by-line, not as a buffered dump.
- [ ] CI green on this PR (waiting for first run)
- [ ] Tomorrow 7am cron (2026-05-28) produces a usable log under the new pty wrap

If tomorrow's cron is still slow but the log now shows per-phase progress, follow-up PR on `startaitools-6jf` targets the actual hot phase. If the log is still silent, Phase 1a needs rework.

Refs `startaitools-m7d`, `startaitools-6jf`.

- Jeremy Longshore
intentsolutions.io