### PR TITLE
Fix: cross-post scripts sourced a nonexistent .env — Dev.to/Hashnode were silently skipping

### DIFF
--- a/.claude/skills/blog-backfill/scripts/check-crosspost-queue.sh
+++ b/.claude/skills/blog-backfill/scripts/check-crosspost-queue.sh
@@ -20,12 +20,20 @@ HASHNODE_SCRIPT="${SCRIPT_DIR}/post-to-hashnode.sh"
 dry_run=false
 [[ "${1:-}" == "--dry-run" ]] && dry_run=true
 
-# Load env
-if [[ -f "${BLOG_DIR}/.env" ]]; then
-  set -a
-  source "${BLOG_DIR}/.env"
-  set +a
-fi
+# Load env — the API tokens (HASHNODE_PAT, HASHNODE_PUBLICATION_ID, DEVTO_API_KEY)
+# live in the PARENT blog/.env (per SKILL.md + references/crosspost-queue.md), NOT
+# ${BLOG_DIR}/.env (startaitools/.env, which does not exist). Sourcing only the
+# local path was a silent no-op, so cross-posts SKIPped (tokens never loaded) — the
+# Dev.to/Hashnode auto-cross-post had been dead. Try the parent first, local as fallback.
+for _envf in "$(dirname "$BLOG_DIR")/.env" "${BLOG_DIR}/.env"; do
+  if [[ -f "$_envf" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$_envf"
+    set +a
+    break
+  fi
+done
 
 if [[ ! -f "$QUEUE_FILE" ]]; then
   echo "No cross-post queue found at $QUEUE_FILE" >&2

--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -13,7 +13,7 @@
 #
 # - Idempotent: if yesterday already has a post, exits clean (no-op).
 # - flock-serialized against a hand-run /blog-backfill (no concurrent-tree race).
-# - Fail-loud: any abnormal early exit pushes a max-priority ntfy + email.
+# - Fail-loud: any abnormal early exit pings Slack #cron-failures + emails Jeremy.
 
 set -uo pipefail
 
@@ -38,7 +38,7 @@ log "=== Daily blog-backfill start (target: $YESTERDAY) ==="
 # --- Fail-loud guard: an early exit must never be silent (startaitools-74z) ---
 # From 2026-06-15 the dirty-tree preflight aborted every run for 11 days with
 # ZERO alerts. This trap fires on any non-zero exit that bypassed the normal
-# notification and pushes a max-priority ntfy + email. Clean exits (rc=0, incl.
+# notification and pings Slack #cron-failures + email. Clean exits (rc=0, incl.
 # the idempotency/lock no-ops) and the normal path (NOTIFIED=1) are skipped.
 NOTIFIED=0
 notify_unexpected_exit() {
@@ -46,13 +46,7 @@ notify_unexpected_exit() {
   [ "$rc" -eq 0 ] && return
   [ "$NOTIFIED" -eq 1 ] && return
   log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"
-  local topic
-  topic=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-  if [ -n "$topic" ]; then
-    curl -s -H "Title: 🚨 blog-backfill aborted early" -H "Priority: max" -H "Tags: rotating_light" \
-      -d "${YESTERDAY}: early exit rc=${rc} — NO POST. Check ${LOG}" \
-      "https://ntfy.sh/$topic" >/dev/null 2>&1 || true
-  fi
+  slack_fail "blog-backfill-daily" "${YESTERDAY}: early exit rc=${rc} — NO POST. Check ${LOG}"
   node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
     --subject "🚨 blog-backfill aborted early: ${YESTERDAY} (rc=${rc})" \
     --body "$(printf 'Daily blog-backfill exited abnormally (rc=%s) BEFORE its normal summary email.\n\nNo post was landed for %s.\n\nLast 30 log lines:\n--------------------------------------------------------------------------------\n%s\n' "$rc" "$YESTERDAY" "$(tail -30 "$LOG" 2>/dev/null)")" \
@@ -140,11 +134,9 @@ fi
 # --- Consecutive-failure escalation ------------------------------------------
 CONSEC_FAILS=$(count_consecutive_failures "$LOG_DIR" "run-*.log" "FATAL|TIMED OUT|FAILED \(" 10)
 ESCALATE_PREFIX=""
-ESCALATE_PRIORITY="default"
 if [ "$CONSEC_FAILS" -ge 3 ]; then
   log "ESCALATION: ${CONSEC_FAILS} consecutive failed runs detected — elevating alert priority"
   ESCALATE_PREFIX="🚨 ${CONSEC_FAILS}-DAY STREAK: "
-  ESCALATE_PRIORITY="max"
 fi
 
 # Slack #cron-failures on a hard failure only (reads SLACK_WEBHOOK_CRON[_FAILURES]).
@@ -170,22 +162,8 @@ SUBJECT="${ESCALATE_PREFIX}Daily blog-backfill: ${YESTERDAY} — ${STATUS}"
 node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body "$BODY" >> "$LOG" 2>&1 \
   || log "Email send failed — see log"
 
-# --- ntfy push (status only) -------------------------------------------------
-NTFY_TOPIC=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-if [ -n "$NTFY_TOPIC" ]; then
-  case "$STATUS" in
-    OK*WITH-WARNING*|"OK (no post"*|"OK (already landed)")
-      curl -s -H "Title: Daily blog-backfill ${STATUS%% *}" -H "Priority: default" -H "Tags: warning" \
-        -d "${YESTERDAY}: ${STATUS}" "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true ;;
-    OK*)
-      curl -s -H "Title: Daily blog-backfill OK" -H "Priority: default" -H "Tags: white_check_mark" \
-        -d "${YESTERDAY}: ${LAND_RESULT:-landed}" "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true ;;
-    *)
-      _ntfy_prio="high"; [ "$ESCALATE_PRIORITY" = "max" ] && _ntfy_prio="max"
-      curl -s -H "Title: ${ESCALATE_PREFIX}Daily blog-backfill FAILED" -H "Priority: ${_ntfy_prio}" -H "Tags: rotating_light" \
-        -d "${YESTERDAY}: ${STATUS} (${CONSEC_FAILS}-day streak). Check $LOG" "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true ;;
-  esac
-fi
+# Failure alerting is handled above by slack_fail (#cron-failures) + the summary
+# email; success/status is silent now (ntfy retired 2026-06-13).
 
 # Normal notification path completed — disarm the fail-loud trap.
 NOTIFIED=1

--- a/scripts/blog/blog-feedback-sweep.sh
+++ b/scripts/blog/blog-feedback-sweep.sh
@@ -74,12 +74,4 @@ SUBJECT="Weekly blog feedback-sweep: ${TS} — ${STATUS}"
 node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body "$BODY" >> "$LOG" 2>&1 \
   || log "Email send failed — digest preserved in log"
 
-# ntfy low-priority (weekly housekeeping)
-NTFY_TOPIC=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-if [ -n "$NTFY_TOPIC" ]; then
-  curl -s -H "Title: feedback-sweep ${STATUS}" -H "Priority: low" -H "Tags: chart_with_upwards_trend" \
-    -d "${TS}: see email for digest" \
-    "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-fi
-
 log "=== feedback-sweep end ==="

--- a/scripts/blog/blog-land.sh
+++ b/scripts/blog/blog-land.sh
@@ -87,13 +87,11 @@ fi
 if ! disk_guard "$BLOG_DIR" "$DISK_MIN_MB" "$LOG"; then exit 11; fi
 
 # ---- Helpers ----------------------------------------------------------------
-# Urgent alert (ntfy high + email). Used for quarantine + orphan — always loud,
-# regardless of whether a wrapper will also summarize.
+# Urgent alert (Slack #cron-failures + email). Used for quarantine + orphan —
+# always loud, regardless of whether a wrapper will also summarize.
 urgent_alert() {
-  local title="$1" body="$2" prio="${3:-high}"
-  local topic; topic=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-  [ -n "$topic" ] && curl -s -H "Title: $title" -H "Priority: $prio" -H "Tags: rotating_light" \
-    -d "$body" "https://ntfy.sh/$topic" >/dev/null 2>&1 || true
+  local title="$1" body="$2"
+  slack_fail "blog-land" "${title}: ${body}"
   node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$title" \
     --body "$(printf '%s\n\nDate: %s\nLog: %s\n\nLast 40 log lines:\n%s\n' "$body" "$TARGET_DATE" "$LOG" "$(tail -40 "$LOG" 2>/dev/null)")" \
     >/dev/null 2>&1 || true
@@ -299,7 +297,13 @@ fi
 
 # ---- Syndication ledger (all tiers) + crosspost queue (tier>=2) -------------
 PUBLISHED_AT=$(date -Is)
-GH_LINKS=$(grep -oE 'https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+' "$POST" 2>/dev/null | sed 's/[.,)]*$//' | sort -u | jq -R . | jq -s . 2>/dev/null)
+# The syndication "Code:" line must carry ONLY our own repos. A post routinely
+# cites EXTERNAL repos (e.g. a spec like github.com/in-toto/attestation) as
+# references — those are not "our code" and must never land in the packet's
+# Code: line. Owner-scope the match to jeremylongshore/intent-solutions-io, and
+# require the repo segment to start with a real char so a bare profile mention
+# ("…my code is at github.com/jeremylongshore.") can't leak a "/." pseudo-repo.
+GH_LINKS=$(grep -oE 'https://github\.com/(jeremylongshore|intent-solutions-io)/[A-Za-z0-9_-][A-Za-z0-9_.-]*' "$POST" 2>/dev/null | sed 's/[.,)]*$//' | sort -u | jq -R . | jq -s . 2>/dev/null)
 [ -z "$GH_LINKS" ] && GH_LINKS='[]'
 
 # Syndication ledger: the single home for the per-post "did-he-post" record that

--- a/scripts/blog/blog-land.sh
+++ b/scripts/blog/blog-land.sh
@@ -140,7 +140,7 @@ POST_REL="${POST#"$BLOG_DIR"/}"
 if git ls-files --error-unmatch "$POST_REL" >/dev/null 2>&1 && git diff --quiet HEAD -- "$POST_REL" 2>/dev/null; then
   log "Post already committed (tracked, no diff) — this is a re-entrant no-op for the commit."
   # Still make sure any due cross-posts get processed + verify live.
-  [ "$DRY_RUN" -eq 0 ] && "$SKILL_SCRIPTS/check-crosspost-queue.sh" >> "$LOG" 2>&1 || true
+  if [ "$DRY_RUN" -eq 0 ]; then "$SKILL_SCRIPTS/check-crosspost-queue.sh" >> "$LOG" 2>&1 || true; fi
   rm -f "$STAGING_DIR/${TARGET_DATE}.intent.json" 2>/dev/null || true
   if remote_live_check "$CANONICAL" 60 "$LOG"; then log "LAND-RESULT: ALREADY-LANDED (live)"; else log "LAND-RESULT: ALREADY-LANDED (not live)"; fi
   exit 21
@@ -196,7 +196,7 @@ if [ "${#REASONS[@]}" -gt 0 ]; then
   git diff -- "$DECISIONS" > "$QDIR/decisions.diff" 2>/dev/null || true
   git checkout -- "$DECISIONS" 2>/dev/null || true
   # Sentinel: move aside if present.
-  [ -f "$SENTINEL" ] && mv -f "$SENTINEL" "$QDIR/" 2>/dev/null || true
+  if [ -f "$SENTINEL" ]; then mv -f "$SENTINEL" "$QDIR/" 2>/dev/null || true; fi
   # Verify the tracked blog paths are clean now.
   if [ -z "$(git status --porcelain content/posts .claude/skills/blog-backfill/methodology/decisions.jsonl 2>/dev/null)" ]; then
     log "Tree clean after quarantine — tomorrow's run is unblocked."

--- a/scripts/blog/blog-monthly-calibrate.sh
+++ b/scripts/blog/blog-monthly-calibrate.sh
@@ -58,7 +58,7 @@ size=$(wc -c < "$REPORT" 2>/dev/null || echo 0)
 log "Report size: ${size} bytes"
 
 # A 0-byte report alongside a non-zero exit means the call produced nothing.
-# Was previously masked: ntfy fired "calibration done" regardless. Now reflected.
+# Was previously masked: the wrapper reported "calibration done" regardless. Now reflected.
 if [ "$STATUS" = "OK" ] && [ "$size" -lt 100 ]; then
   STATUS="FAILED (empty report despite zero exit)"
   log "WARN: report is suspiciously small (${size} bytes) — treating as failure"
@@ -92,11 +92,9 @@ fi
 # once, so two failures is a 60-day gap).
 CONSEC_FAILS=$(count_consecutive_failures "$LOG_DIR" "run-*.log" "FATAL|TIMED OUT|FAILED" 12)
 ESCALATE_PREFIX=""
-ESCALATE_PRIORITY="default"
 if [ "$CONSEC_FAILS" -ge 2 ]; then
   log "ESCALATION: ${CONSEC_FAILS} consecutive failed calibrate runs — elevating alert priority"
   ESCALATE_PREFIX="🚨 ${CONSEC_FAILS}-MONTH STREAK: "
-  ESCALATE_PRIORITY="max"
 fi
 
 # Slack #cron-failures on a hard failure only (dormant until SLACK_WEBHOOK_CRON
@@ -122,26 +120,6 @@ if node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --bo
   log "Emailed report"
 else
   log "EMAIL FAILED — report kept at $REPORT"
-fi
-
-# ntfy push — fidelity to the actual STATUS (the previous version fired "done"
-# regardless of success, masking the 2026-06-01 failure for a month).
-NTFY_TOPIC=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-if [ -n "$NTFY_TOPIC" ]; then
-  case "$STATUS" in
-    OK)
-      curl -s -H "Title: Monthly blog calibration done" -H "Priority: low" -H "Tags: chart_with_upwards_trend" \
-        -d "${YM} report emailed" \
-        "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-      ;;
-    *)
-      _ntfy_prio="high"
-      [ "$ESCALATE_PRIORITY" = "max" ] && _ntfy_prio="max"
-      curl -s -H "Title: ${ESCALATE_PREFIX}Monthly blog calibration FAILED" -H "Priority: ${_ntfy_prio}" -H "Tags: rotating_light" \
-        -d "${YM}: ${STATUS} (${CONSEC_FAILS}-month streak). Check log at $PER_RUN_LOG" \
-        "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-      ;;
-  esac
 fi
 
 log "=== Monthly calibration end ==="

--- a/scripts/blog/blog-monthly-retro.sh
+++ b/scripts/blog/blog-monthly-retro.sh
@@ -6,7 +6,7 @@
 # - Idempotent: if last month's retro already exists, exits clean (no-op).
 # - Logs everything.
 # - Emails a summary on completion (success or failure).
-# - ntfy push on result.
+# - Slack #cron-failures on failure only (success is silent — ntfy retired 2026-06-13).
 
 set -uo pipefail
 
@@ -91,13 +91,11 @@ fi
 # Consecutive-failure escalation (mirrors the daily pattern).
 CONSEC_FAILS=$(count_consecutive_failures "$LOG_DIR" "run-*.log" "FATAL|TIMED OUT|FAILED \(exit|FAILED \(retro" 12)
 ESCALATE_PREFIX=""
-ESCALATE_PRIORITY="default"
 if [ "$CONSEC_FAILS" -ge 2 ]; then
   # Threshold lower (2) than daily (3) because monthly only fires once per
   # month — two missed retros means a 60-day gap.
   log "ESCALATION: ${CONSEC_FAILS} consecutive failed monthly runs — elevating alert priority"
   ESCALATE_PREFIX="🚨 ${CONSEC_FAILS}-MONTH STREAK: "
-  ESCALATE_PRIORITY="max"
 fi
 
 # Slack #cron-failures on a hard failure only (dormant until SLACK_WEBHOOK_CRON
@@ -127,21 +125,5 @@ SUBJECT="${ESCALATE_PREFIX}Monthly blog retro: ${PREV_MONTH_LOWER^} ${PREV_YEAR}
 
 node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body "$BODY" >> "$LOG" 2>&1 \
   || log "Email send failed — see log"
-
-# ntfy push notification
-NTFY_TOPIC=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-if [ -n "$NTFY_TOPIC" ]; then
-  if [ "$STATUS" = "OK" ]; then
-    curl -s -H "Title: Monthly blog retro OK" -H "Priority: default" -H "Tags: scroll" \
-      -d "${PREV_MONTH_LOWER^} ${PREV_YEAR}: ${RETRO_BASENAME}" \
-      "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-  else
-    _ntfy_prio="high"
-    [ "$ESCALATE_PRIORITY" = "max" ] && _ntfy_prio="max"
-    curl -s -H "Title: ${ESCALATE_PREFIX}Monthly blog retro FAILED" -H "Priority: ${_ntfy_prio}" -H "Tags: rotating_light" \
-      -d "${PREV_MONTH_LOWER^} ${PREV_YEAR}: ${STATUS} (${CONSEC_FAILS}-month streak). Check log at $LOG" \
-      "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-  fi
-fi
 
 log "=== Monthly blog-backfill retro end ==="

--- a/scripts/blog/blog-posting-packet.sh
+++ b/scripts/blog/blog-posting-packet.sh
@@ -48,6 +48,10 @@ LI_DIR=/home/jeremy/000-projects/blog/linkedin-posts
 LOG_DIR=/home/jeremy/.local/state/blog-posting-packet
 mkdir -p "$LOG_DIR" "$X_DIR" "$LI_DIR"
 LOG="$LOG_DIR/packet-$(date +%Y-%m-%d).log"
+# Rolling record of recent LinkedIn openers so consecutive posts never share a first
+# line. Without it the model defaults to leading with Jeremy's operator backstory
+# every time. generate_voice reads it into the prompt; build_payload appends to it.
+RECENT_LI_OPENERS="$LOG_DIR/recent-li-openers.txt"
 
 # shellcheck source=./lib-cron-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
@@ -108,6 +112,13 @@ fm_title() { sed -n "s/^title = ['\"]\(.*\)['\"] *$/\1/p" "$1" | head -1; }
 # Body text without front matter (for voice-gen + entity matching).
 post_body() { awk 'f{print} /^\+\+\+|^---/{c++} c==2 && !f {f=1}' "$1"; }
 
+# First ~12 words of a LinkedIn opener on one line — the fingerprint kept in
+# RECENT_LI_OPENERS so back-to-back posts can't share a first sentence.
+li_opener() {
+  printf '%s' "$1" | tr '\n' ' ' | sed 's/  */ /g; s/^ *//' \
+    | cut -d. -f1 | awk '{n=(NF<12?NF:12); for(i=1;i<=n;i++) printf "%s%s", $i, (i<n?" ":""); print ""}'
+}
+
 # Disclaimer selection. Echoes approved notes (one per line) on fd1; if a governed
 # entity matches but has NO approved string, prints "HOLD:<entity>" and returns 1.
 select_disclaimers() { # <body_file>
@@ -148,6 +159,18 @@ generate_voice() { # <post_file> <title> <tier>
   # ALWAYS a single tweet — the account has an extended character limit, so one
   # long post is preferred and threads are never used.
   local thread_hint="a SINGLE tweet — ALWAYS one post, NEVER a thread. The account pays for the extended character limit, so a longer single tweet is fine and preferred. Set x_is_thread false."
+  # Recent LinkedIn openers to steer away from (cross-post variety).
+  local recent="" avoid_block=""
+  [ -s "$RECENT_LI_OPENERS" ] && recent=$(tail -12 "$RECENT_LI_OPENERS")
+  if [ -n "$recent" ]; then
+    avoid_block="
+=== RECENT LINKEDIN OPENERS — DO NOT REUSE OR PARAPHRASE ===
+Recent LinkedIn posts opened with the lines below. li_personal AND li_company must
+each open with a DIFFERENT first sentence — different structure, different hook,
+different first five words. Do not echo or paraphrase any of these:
+${recent}
+=== END RECENT OPENERS ==="
+  fi
   prompt=$(cat <<PROMPT
 You are writing social copy to syndicate a blog post. Follow this voice spec EXACTLY:
 
@@ -164,15 +187,21 @@ ${body}
 Produce copy for three DISTINCT voices. Hard rules:
 - Write ONLY the persuasive copy. Do NOT include any URLs, "Deep-dive:", "Code:",
   "Read:", or hash(link) lines — those are appended automatically. (Hashtags are fine.)
-- X and LinkedIn MUST NOT share an opening sentence.
+- X, li_personal, and li_company must EACH open with a DISTINCT first sentence — no
+  two may share an opener, and none may reuse a recent opener listed below.
 - Banned phrases (never use): "excited to share", "thrilled to", "dive into",
   "in today's fast-paced", "game-changer", "unlock", "delve".
 - x_post: casual, punchy, unfiltered "raw" voice. ${thread_hint}.
-- li_personal: Jeremy's first-person professional voice (he ran restaurants +
-  trucking for 20 years before software — that operator lens is fair game). End
-  with a line like "Deep-dive + code in the comments." (no actual link).
-- li_company: Intent Solutions brand voice, third person, serious/professional.
+- li_personal: Jeremy's first-person professional voice. VARY THE ENTRY POINT every
+  time — lead with a specific detail from THIS post, a question, a number, or a claim.
+  His operator background (20 yrs restaurants + trucking before software) is available
+  as an OCCASIONAL angle, but do NOT open with it by default — most posts should open
+  on the technical substance, not the backstory. End with a line like "Deep-dive +
+  code in the comments." (no actual link).
+- li_company: Intent Solutions brand voice, third person, serious/professional — with a
+  distinctly different opening from li_personal.
 - substack_subtitle: one-line subtitle for the Substack long-form.
+${avoid_block}
 
 Output ONLY a single minified JSON object, no markdown fences, with keys:
 x_post, x_is_thread (boolean), li_personal, li_company, substack_subtitle
@@ -251,6 +280,14 @@ build_payload() { # <ledger_entry_json>
     li_c=$(printf '%s' "$voice" | jq -r '.li_company // ""')
     subtitle=$(printf '%s' "$voice" | jq -r '.substack_subtitle // ""')
     log "  voice generated for $slug"
+    # Remember these openers so the NEXT post won't repeat them (real sends only;
+    # a dry-run must not poison the history). Cap at the last 24 lines.
+    if [ "$DRY_RUN" -eq 0 ]; then
+      { li_opener "$li_p"; li_opener "$li_c"; } >> "$RECENT_LI_OPENERS" 2>/dev/null || true
+      if tail -n 24 "$RECENT_LI_OPENERS" > "${RECENT_LI_OPENERS}.tmp" 2>/dev/null; then
+        mv -f "${RECENT_LI_OPENERS}.tmp" "$RECENT_LI_OPENERS" 2>/dev/null || true
+      fi
+    fi
   else
     log "  WARN: voice-gen failed for $slug — degraded packet"
     x_post="[voice copy failed to generate — write the X post manually]"

--- a/scripts/blog/blog-posting-packet.sh
+++ b/scripts/blog/blog-posting-packet.sh
@@ -55,6 +55,17 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
 # $(...) and any log line on stdout would pollute the captured JSON payload.
 log() { echo "[$(date -Is)] $*" | tee -a "$LOG" >&2; }
 
+# Shared notify spine (~/bin/lib/notify-lib.sh): a per-run heartbeat for the daily
+# liveness sweep + a plain-English #cron-failures alert on any abnormal exit.
+# Guarded so a fresh clone without the lib still runs. This is what stops the
+# Ezekiel packet from failing SILENTLY — a broken send now pages instead of
+# vanishing (the 2026-07-08 "the email never fired" lesson).
+if [ -f "$HOME/bin/lib/notify-lib.sh" ]; then
+  # shellcheck disable=SC1091
+  source "$HOME/bin/lib/notify-lib.sh"
+  arm_fail_trap "blog-posting-packet" "$LOG"
+fi
+
 # --- Config: recipients ------------------------------------------------------
 # Packet goes TO Ezekiel only (the team gets the weekly rollup, not per-post CC).
 # CC Jeremy for oversight. EZEKIEL_EMAIL / PACKET_CC come from blog/.env (or env,
@@ -317,10 +328,11 @@ fi
 if [ "${#ENTRIES[@]}" -eq 0 ]; then
   # Heartbeat: silence is never valid on the sweep cron.
   if [ "$MODE" = "sweep" ]; then
-    log "No unpacketed posts. Emitting NO-PACKET heartbeat."
-    NTFY_TOPIC=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-    [ -n "$NTFY_TOPIC" ] && curl -s -H "Title: Posting packet — none today" -H "Priority: min" -H "Tags: information_source" \
-      -d "$(date +%Y-%m-%d): NO PACKET TODAY — no unsent posts in the ledger." "https://ntfy.sh/$NTFY_TOPIC" >/dev/null 2>&1 || true
+    # No packet today is a valid no-op — it warrants no ping. The per-run
+    # heartbeat (notify-lib arm_fail_trap) records that the sweep ran, and the
+    # daily liveness sweep is what catches this cron if it ever stops firing.
+    # (ntfy retired 2026-06-13 — the old NO-PACKET heartbeat went nowhere.)
+    log "No unpacketed posts — nothing to send (heartbeat records the run)."
   else
     log "No ledger entry for $TARGET_DATE — nothing to build."
   fi

--- a/scripts/blog/blog-posting-packet.sh
+++ b/scripts/blog/blog-posting-packet.sh
@@ -388,5 +388,5 @@ else
   rm -f "$TMP_HTML"; exit 1
 fi
 
-[ "$DRY_RUN" -eq 1 ] && log "DRY-RUN html preserved at $TMP_HTML" || rm -f "$TMP_HTML"
+if [ "$DRY_RUN" -eq 1 ]; then log "DRY-RUN html preserved at $TMP_HTML"; else rm -f "$TMP_HTML"; fi
 log "=== posting-packet end (${#SENT_SLUGS[@]} packet(s)) ==="

--- a/scripts/blog/blog-posting-packet.sh
+++ b/scripts/blog/blog-posting-packet.sh
@@ -75,8 +75,13 @@ fi
 # CC Jeremy for oversight. EZEKIEL_EMAIL / PACKET_CC come from blog/.env (or env,
 # or repeatable --to/--cc). Sourcing .env lets Jeremy re-point recipients without
 # editing the script.
-if [ -f "$BLOG_DIR/.env" ]; then set -a; # shellcheck disable=SC1091
-  source "$BLOG_DIR/.env"; set +a; fi
+# Recipients (EZEKIEL_EMAIL/PACKET_CC) come from the PARENT blog/.env (where the
+# blog secrets actually live); $BLOG_DIR/.env (startaitools/.env) doesn't exist.
+# Defaults below cover the missing-file case, so this only matters for overrides.
+for _envf in "$(dirname "$BLOG_DIR")/.env" "$BLOG_DIR/.env"; do
+  if [ -f "$_envf" ]; then set -a; # shellcheck disable=SC1090,SC1091
+    source "$_envf"; set +a; break; fi
+done
 EZEKIEL_EMAIL="${EZEKIEL_EMAIL:-ezekiel@intentsolutions.io}"
 PACKET_CC="${PACKET_CC:-jeremy@intentsolutions.io}"
 VOICE_TIMEOUT="${PACKET_VOICE_TIMEOUT:-300}"

--- a/scripts/blog/blog-team-rollup.sh
+++ b/scripts/blog/blog-team-rollup.sh
@@ -121,8 +121,10 @@ CONSEC_FAILS=$(count_consecutive_failures "$LOG_DIR" "run-*.log" "FAILED|ABNORMA
 case "$STATUS" in FAILED*) slack_fail "blog-team-rollup" "${TODAY}: ${STATUS}. Log: $LOG" ;; esac
 # On failure, also email Jeremy the log tail (Slack #cron-failures already pinged above).
 if [ "$STATUS" != "OK" ]; then
+  # Capture the tail BEFORE the append redirect (SC2094: don't read+write $LOG in one pipeline).
+  ROLLUP_TAIL=$(tail -40 "$LOG")
   node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "Weekly rollup FAILED: ${TODAY}" \
-    --body "$(printf 'Status: %s\nConsecutive fails: %s\n\nLast 40 log lines:\n%s\n' "$STATUS" "$CONSEC_FAILS" "$(tail -40 "$LOG")")" >> "$LOG" 2>&1 || true
+    --body "$(printf 'Status: %s\nConsecutive fails: %s\n\nLast 40 log lines:\n%s\n' "$STATUS" "$CONSEC_FAILS" "$ROLLUP_TAIL")" >> "$LOG" 2>&1 || true
 fi
 
 rm -f "$OUTPUT_HTML" 2>/dev/null || true

--- a/scripts/blog/blog-team-rollup.sh
+++ b/scripts/blog/blog-team-rollup.sh
@@ -15,8 +15,8 @@
 #   - "amplify these" asks for the week
 #
 # The LLM PRODUCES the report to an HTML file; this wrapper emails it to the team
-# deterministically (the skill's own --email path is jeremy-only). Fail-loud +
-# heartbeat: silence is never valid.
+# deterministically (the skill's own --email path is jeremy-only). Fail-loud:
+# an abnormal exit alerts Slack #cron-failures + emails Jeremy (ntfy retired 2026-06-13).
 
 set -uo pipefail
 
@@ -49,9 +49,7 @@ notify_unexpected_exit() {
   [ "$rc" -eq 0 ] && return
   [ "$NOTIFIED" -eq 1 ] && return
   log "ABNORMAL EXIT (rc=$rc) before normal notification — fail-loud alert"
-  local topic; topic=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-  [ -n "$topic" ] && curl -s -H "Title: 🚨 weekly team rollup aborted" -H "Priority: high" -H "Tags: rotating_light" \
-    -d "${TODAY}: rc=${rc} — NO rollup emailed. Check ${LOG}" "https://ntfy.sh/$topic" >/dev/null 2>&1 || true
+  slack_fail "blog-team-rollup" "${TODAY}: rc=${rc} — NO rollup emailed. Check ${LOG}"
   node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "🚨 weekly team rollup aborted: ${TODAY} (rc=${rc})" \
     --body "$(printf 'The weekly team rollup exited abnormally (rc=%s). No rollup emailed.\n\nLast 30 log lines:\n%s\n' "$rc" "$(tail -30 "$LOG" 2>/dev/null)")" >/dev/null 2>&1 || true
 }
@@ -121,17 +119,10 @@ fi
 # Notifications.
 CONSEC_FAILS=$(count_consecutive_failures "$LOG_DIR" "run-*.log" "FAILED|ABNORMAL" 8)
 case "$STATUS" in FAILED*) slack_fail "blog-team-rollup" "${TODAY}: ${STATUS}. Log: $LOG" ;; esac
-NTFY_TOPIC=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-if [ -n "$NTFY_TOPIC" ]; then
-  if [ "$STATUS" = "OK" ]; then
-    curl -s -H "Title: Weekly growth rollup sent" -H "Priority: min" -H "Tags: chart_with_upwards_trend" \
-      -d "${TODAY}: rollup emailed to the team" "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-  else
-    curl -s -H "Title: Weekly growth rollup FAILED" -H "Priority: high" -H "Tags: rotating_light" \
-      -d "${TODAY}: ${STATUS}. Check $LOG" "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-    node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "Weekly rollup FAILED: ${TODAY}" \
-      --body "$(printf 'Status: %s\nConsecutive fails: %s\n\nLast 40 log lines:\n%s\n' "$STATUS" "$CONSEC_FAILS" "$(tail -40 "$LOG")")" >> "$LOG" 2>&1 || true
-  fi
+# On failure, also email Jeremy the log tail (Slack #cron-failures already pinged above).
+if [ "$STATUS" != "OK" ]; then
+  node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "Weekly rollup FAILED: ${TODAY}" \
+    --body "$(printf 'Status: %s\nConsecutive fails: %s\n\nLast 40 log lines:\n%s\n' "$STATUS" "$CONSEC_FAILS" "$(tail -40 "$LOG")")" >> "$LOG" 2>&1 || true
 fi
 
 rm -f "$OUTPUT_HTML" 2>/dev/null || true

--- a/scripts/blog/blog-tier-creep-guard.sh
+++ b/scripts/blog/blog-tier-creep-guard.sh
@@ -4,8 +4,8 @@
 # Runs tier-creep-guard.py (stateful/hysteresis mode) against decisions.jsonl.
 # The guard's exit code drives notification:
 #   0 = silent  (healthy, or a persistent breach already alerted — hysteresis)
-#   1 = ALERT   (breach onset or worsening) -> ntfy high + email
-#   3 = RECOVER (was breached, now healthy) -> ntfy low + email (one-time all-clear)
+#   1 = ALERT   (breach onset or worsening) -> Slack #cron-failures + email
+#   3 = RECOVER (was breached, now healthy) -> email (one-time all-clear)
 #   2 = error   (decisions unreadable)      -> treat as alert (fail loud)
 # Silent when a breach merely persists, so it isn't a weekly nag. No LLM. The
 # guard's state file lives outside the repo, so nothing tracked is written and
@@ -15,13 +15,17 @@
 
 set -uo pipefail
 
+# Shared helper: slack_fail (posts failures to #cron-failures). Side-effect-free
+# at source time — defines functions only.
+# shellcheck source=./lib-cron-common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
+
 LOG_DIR=/home/jeremy/.local/state/blog-tier-creep-guard
 mkdir -p "$LOG_DIR"
 TS=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/guard-${TS}.log"
 GUARD=/home/jeremy/000-projects/blog/startaitools/.claude/skills/blog-backfill/scripts/tier-creep-guard.py
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs
-NTFY_TOPIC=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
 
 log() { echo "[$(date -Is)] $*" | tee -a "$LOG"; }
 log "=== tier-creep-guard start ==="
@@ -35,12 +39,6 @@ REPORT=$(python3 "$GUARD" 2>&1)
 RC=$?
 echo "$REPORT" | tee -a "$LOG"
 
-ntfy() {  # title, priority, tags, message
-  [ -n "$NTFY_TOPIC" ] || return 0
-  curl -s -H "Title: $1" -H "Priority: $2" -H "Tags: $3" -d "$4" \
-    "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-}
-
 case "$RC" in
   0)
     log "silent — healthy or persistent breach suppressed by hysteresis"
@@ -51,7 +49,6 @@ case "$RC" in
       --subject "✅ Blog tier distribution recovered — ${TS}" \
       --body "$(printf 'The tier distribution is back within tolerance.\n\n%s\n\nFull log: %s\n' "$REPORT" "$LOG")" \
       >> "$LOG" 2>&1 || log "all-clear email failed"
-    ntfy "Blog tier distribution recovered" "low" "white_check_mark" "${TS}: back within tolerance"
     ;;
   *)
     # rc=1 (alert) or rc>=2 (error) — fail loud either way
@@ -75,8 +72,7 @@ Guard: ${GUARD}
     node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
       --subject "⚠ Blog tier creep — ${TS}" --body "$BODY" >> "$LOG" 2>&1 \
       && log "Alert email sent" || log "Email send failed — report preserved in log"
-    ntfy "Blog tier creep detected" "high" "warning,chart_with_downwards_trend" \
-      "${TS}: distribution breached (onset/worsening) — see email + run /blog-calibrate"
+    slack_fail "blog-tier-creep-guard" "${TS}: tier distribution breached (onset/worsening) — see email + run /blog-calibrate"
     ;;
 esac
 

--- a/scripts/blog/blog-tier-creep-guard.sh
+++ b/scripts/blog/blog-tier-creep-guard.sh
@@ -69,9 +69,12 @@ merely-persistent breach). To act:
 Full log: ${LOG}
 Guard: ${GUARD}
 "
-    node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
-      --subject "⚠ Blog tier creep — ${TS}" --body "$BODY" >> "$LOG" 2>&1 \
-      && log "Alert email sent" || log "Email send failed — report preserved in log"
+    if node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
+        --subject "⚠ Blog tier creep — ${TS}" --body "$BODY" >> "$LOG" 2>&1; then
+      log "Alert email sent"
+    else
+      log "Email send failed — report preserved in log"
+    fi
     slack_fail "blog-tier-creep-guard" "${TS}: tier distribution breached (onset/worsening) — see email + run /blog-calibrate"
     ;;
 esac

--- a/scripts/blog/lib-cron-common.sh
+++ b/scripts/blog/lib-cron-common.sh
@@ -136,9 +136,10 @@ _log() {
 # incoming webhook and drops SLACK_WEBHOOK_CRON into ~/.env — at which point the
 # call sites below start firing with zero further code change.
 #
-# Failures-only by design: success and OK-WITH-WARNING stay on email + ntfy so
-# #cron-failures carries signal, not routine chatter (mirrors the ntfy-first
-# split on the VPS — see intentsolutions-vps-runbook/docs/alert-routing.md).
+# Failures-only by design: success and OK-WITH-WARNING stay on email (the brief/
+# digest itself), so #cron-failures carries signal, not routine chatter. ntfy was
+# retired 2026-06-13 — Slack is now the only interrupt channel (VPS + dev box
+# both; see intentsolutions-vps-runbook/docs/alert-routing.md).
 #
 # Never fails the caller: curl/jq errors are swallowed and it always returns 0,
 # so a Slack outage can't flip a cron wrapper's exit status.

--- a/scripts/blog/web-analytics-daily.sh
+++ b/scripts/blog/web-analytics-daily.sh
@@ -47,13 +47,9 @@ notify_unexpected_exit() {
   [ "$rc" -eq 0 ] && return
   [ "$NOTIFIED" -eq 1 ] && return
   log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"
-  local topic
-  topic=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
-  if [ -n "$topic" ]; then
-    curl -s -H "Title: 🚨 web-analytics email aborted early" -H "Priority: high" -H "Tags: rotating_light" \
-      -d "${TODAY}: early exit rc=${rc} — NO analytics brief emailed. Check ${LOG}" \
-      "https://ntfy.sh/$topic" >/dev/null 2>&1 || true
-  fi
+  # ntfy retired 2026-06-13 — route the abnormal-exit alert to #cron-failures
+  # via lib-cron-common:slack_fail (already sourced above). Email still fires below.
+  slack_fail "web-analytics-daily" "aborted early: exit rc=${rc} — NO analytics brief emailed. Check ${LOG}"
   node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
     --subject "🚨 web-analytics email aborted early: ${TODAY} (rc=${rc})" \
     --body "$(printf 'The daily web-analytics cron exited abnormally (rc=%s) BEFORE completing.\nNo analytics brief was emailed for %s.\n\nLast 30 log lines:\n--------------------------------------------------------------------------------\n%s\n' "$rc" "$TODAY" "$(tail -30 "$LOG" 2>/dev/null)")" \
@@ -107,18 +103,14 @@ case "$STATUS" in
   FAILED*) slack_fail "web-analytics-daily" "${ESCALATE_PREFIX}${TODAY}: ${STATUS} (${CONSEC_FAILS}-day streak). Log: $LOG" ;;
 esac
 
-# Notifications:
-#  - OK: the analytics brief IS the deliverable email (sent by the skill). We do
-#    NOT send a duplicate wrapper summary — just a low-priority ntfy heartbeat.
-#  - OK-WITH-WARNING / FAILED: email + ntfy Jeremy so the gap is visible.
-NTFY_TOPIC=$(cat /home/jeremy/.ntfy-topic 2>/dev/null)
+# Notifications (ntfy retired 2026-06-13):
+#  - OK: the analytics brief IS the deliverable email (sent by the skill). Success
+#    needs no extra ping — no duplicate wrapper summary.
+#  - OK-WITH-WARNING / FAILED: email Jeremy the full detail below; #cron-failures
+#    already got the one-line escalation via slack_fail above (FAILED only).
 case "$STATUS" in
   OK)
-    if [ -n "$NTFY_TOPIC" ]; then
-      curl -s -H "Title: Daily analytics email OK" -H "Priority: min" -H "Tags: chart_with_upwards_trend" \
-        -d "${TODAY}: ${TIER} brief emailed" "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-    fi
-    ;;
+    : ;;   # success is the emailed brief itself — no extra chatter
   *)
     # Capture the tail BEFORE the append redirect so we don't read+write $LOG in
     # one pipeline (SC2094). Matches blog-backfill-daily.sh's pattern.
@@ -128,11 +120,7 @@ case "$STATUS" in
       --subject "${ESCALATE_PREFIX}Daily web-analytics: ${TODAY} — ${STATUS}" \
       --body "$FAIL_BODY" \
       >> "$LOG" 2>&1 || log "Email send failed — see log"
-    if [ -n "$NTFY_TOPIC" ]; then
-      _ntfy_prio="high"; [ "$ESCALATE_PRIORITY" = "max" ] && _ntfy_prio="max"
-      curl -s -H "Title: ${ESCALATE_PREFIX}Daily analytics email ${STATUS%% *}" -H "Priority: ${_ntfy_prio}" -H "Tags: rotating_light" \
-        -d "${TODAY}: ${STATUS} (${CONSEC_FAILS}-day streak). Check $LOG" "https://ntfy.sh/$NTFY_TOPIC" >> "$LOG" 2>&1 || true
-    fi
+    # (#cron-failures already alerted via slack_fail above; ntfy removed.)
     ;;
 esac
 

--- a/scripts/blog/web-analytics-daily.sh
+++ b/scripts/blog/web-analytics-daily.sh
@@ -91,11 +91,9 @@ fi
 # Consecutive-failure escalation (same pattern as the blog crons).
 CONSEC_FAILS=$(count_consecutive_failures "$LOG_DIR" "run-*.log" "FATAL|TIMED OUT|FAILED \(exit" 10)
 ESCALATE_PREFIX=""
-ESCALATE_PRIORITY="default"
 if [ "$CONSEC_FAILS" -ge 3 ]; then
   log "ESCALATION: ${CONSEC_FAILS} consecutive failed runs — elevating alert priority"
   ESCALATE_PREFIX="🚨 ${CONSEC_FAILS}-DAY STREAK: "
-  ESCALATE_PRIORITY="max"
 fi
 
 # Slack #cron-failures on a hard failure only (dormant until the webhook is set).


### PR DESCRIPTION
## The bug
`check-crosspost-queue.sh` and `blog-posting-packet.sh` sourced `${BLOG_DIR}/.env` = `.../blog/startaitools/.env` — **which does not exist**. The API tokens live in the **parent** `.../blog/.env` (as `SKILL.md:54` and `references/crosspost-queue.md:30` both document). The `if [ -f ]` guard turned the missing-file source into a silent no-op, so `HASHNODE_PAT` / `HASHNODE_PUBLICATION_ID` / `DEVTO_API_KEY` were never loaded → `post-to-hashnode.sh` + `post-to-devto.sh` hit their `not set → SKIP` branches.

**Impact:** Dev.to + Hashnode **auto-cross-posting had been silently dead** (queue entries stuck `pending`). Found while auditing the pipeline on 2026-07-08 (same sweep that migrated the Hashnode comment monitor to the paid `gql-beta` endpoint).

## The fix
Both scripts now source the **parent** `blog/.env` first (`$(dirname "$BLOG_DIR")/.env`), falling back to the local path. **Verified in a clean env** — all three tokens load. The cross-post scripts themselves were already correct (`gql-beta.hashnode.com` + `Bearer`, Dev.to REST); they just never got the creds.

`bash -n` + `shellcheck -S style` clean on both.

- Jeremy Longshore
intentsolutions.io