### PR TITLE
fix(blog-cron): harden fail-alerting + wire liveness heartbeats across the blog cron suite

### DIFF
--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -20,6 +20,12 @@ set -uo pipefail
 LOG_DIR=/home/jeremy/.local/state/blog-backfill-daily
 mkdir -p "$LOG_DIR"
 
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; the fail-loud trap below covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-backfill-daily.beat" 2>/dev/null || true
+
 YESTERDAY=$(date -d "yesterday" +%Y-%m-%d)
 LOG="$LOG_DIR/run-${YESTERDAY}.log"
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs

--- a/scripts/blog/blog-feedback-sweep.sh
+++ b/scripts/blog/blog-feedback-sweep.sh
@@ -10,13 +10,46 @@ set -uo pipefail
 
 LOG_DIR=/home/jeremy/.local/state/blog-feedback-sweep
 mkdir -p "$LOG_DIR"
+
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; fail-alerting (below) covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-feedback-sweep.beat" 2>/dev/null || true
+
 TS=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/sweep-${TS}.log"
 SCRIPT=/home/jeremy/000-projects/blog/startaitools/.claude/skills/blog-backfill/scripts/feedback-sweep.py
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs
 
+# Shared helper: slack_fail (posts failures to #cron-failures). Side-effect-free
+# at source time — defines functions only.
+# shellcheck source=./lib-cron-common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
+
 log() { echo "[$(date -Is)] $*" | tee -a "$LOG"; }
 log "=== feedback-sweep start ==="
+
+# --- Fail-loud guard: an early exit must never be silent ----------------------
+# Before this trap the only alerting was a best-effort email whose own failure
+# was merely logged — the FATAL below (feedback-sweep.py missing/not executable)
+# EXITed with ZERO Slack alert. Ported from blog-backfill-daily.sh: this fires on
+# any non-zero exit that bypassed the normal notification and pings Slack
+# #cron-failures + email. Clean exits (rc=0) and the normal path (NOTIFIED=1) are
+# skipped.
+NOTIFIED=0
+notify_unexpected_exit() {
+  local rc=$?
+  [ "$rc" -eq 0 ] && return
+  [ "$NOTIFIED" -eq 1 ] && return
+  log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"
+  slack_fail "blog-feedback-sweep" "${TS}: early exit rc=${rc} — sweep did not complete. Check ${LOG}"
+  node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
+    --subject "🚨 blog-feedback-sweep aborted early: ${TS} (rc=${rc})" \
+    --body "$(printf 'Weekly blog feedback-sweep exited abnormally (rc=%s) BEFORE its normal summary email.\n\nNo digest was sent for %s.\n\nLast 30 log lines:\n--------------------------------------------------------------------------------\n%s\n' "$rc" "$TS" "$(tail -30 "$LOG" 2>/dev/null)")" \
+    >/dev/null 2>&1 || true
+}
+trap notify_unexpected_exit EXIT
 
 if [ ! -x "$SCRIPT" ]; then
   log "FATAL: $SCRIPT not executable"
@@ -74,4 +107,6 @@ SUBJECT="Weekly blog feedback-sweep: ${TS} — ${STATUS}"
 node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body "$BODY" >> "$LOG" 2>&1 \
   || log "Email send failed — digest preserved in log"
 
+# Normal notification path completed — disarm the fail-loud trap.
+NOTIFIED=1
 log "=== feedback-sweep end ==="

--- a/scripts/blog/blog-monthly-calibrate.sh
+++ b/scripts/blog/blog-monthly-calibrate.sh
@@ -8,6 +8,12 @@ LOG_DIR=/home/jeremy/.local/state/blog-monthly-calibrate
 LOG="$LOG_DIR/calibrate.log"
 mkdir -p "$LOG_DIR"
 
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; fail-alerting (below) covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-monthly-calibrate.beat" 2>/dev/null || true
+
 # Shared helpers: preflight_branch_normalize, count_consecutive_failures.
 # shellcheck source=./lib-cron-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
@@ -20,6 +26,27 @@ BLOG_DIR=/home/jeremy/000-projects/blog/startaitools
 
 log() { echo "[$(date -Is)] $*" | tee -a "$LOG" "$PER_RUN_LOG"; }
 log "=== Monthly calibration start (target: $YM) ==="
+
+# --- Fail-loud guard: an early exit must never be silent ----------------------
+# This is one of the two scripts the "Nine Days Silent" postmortem was about: a
+# dirty-tree/worktree FATAL inside preflight_branch_normalize below EXITs before
+# the normal Slack + email path at the bottom, so the failure went unalerted.
+# Ported verbatim from blog-backfill-daily.sh: this trap fires on any non-zero
+# exit that bypassed the normal notification and pings Slack #cron-failures +
+# email. Clean exits (rc=0) and the normal path (NOTIFIED=1) are skipped.
+NOTIFIED=0
+notify_unexpected_exit() {
+  local rc=$?
+  [ "$rc" -eq 0 ] && return
+  [ "$NOTIFIED" -eq 1 ] && return
+  log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"
+  slack_fail "blog-monthly-calibrate" "${YM}: early exit rc=${rc} — NO calibration report. Check ${LOG}"
+  node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
+    --subject "🚨 blog-monthly-calibrate aborted early: ${YM} (rc=${rc})" \
+    --body "$(printf 'Monthly blog calibration exited abnormally (rc=%s) BEFORE its normal summary email.\n\nNo calibration report was produced for %s.\n\nLast 30 log lines:\n--------------------------------------------------------------------------------\n%s\n' "$rc" "$YM" "$(tail -30 "$LOG" 2>/dev/null)")" \
+    >/dev/null 2>&1 || true
+}
+trap notify_unexpected_exit EXIT
 
 # Pre-flight: clean tree, switch to default branch (pivot if held in a sibling
 # worktree), fast-forward. Same helper the daily uses.
@@ -122,4 +149,6 @@ else
   log "EMAIL FAILED — report kept at $REPORT"
 fi
 
+# Normal notification path completed — disarm the fail-loud trap.
+NOTIFIED=1
 log "=== Monthly calibration end ==="

--- a/scripts/blog/blog-monthly-retro.sh
+++ b/scripts/blog/blog-monthly-retro.sh
@@ -13,6 +13,12 @@ set -uo pipefail
 LOG_DIR=/home/jeremy/.local/state/blog-monthly-retro
 mkdir -p "$LOG_DIR"
 
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; fail-alerting (below) covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-monthly-retro.beat" 2>/dev/null || true
+
 # Shared helpers: preflight_branch_normalize, count_consecutive_failures.
 # shellcheck source=./lib-cron-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
@@ -33,9 +39,32 @@ RETRO_FILE="$BLOG_DIR/content/monthly-recaps/${PREV_MONTH_LOWER}-${PREV_YEAR}.md
 log() { echo "[$(date -Is)] $*" | tee -a "$LOG"; }
 log "=== Monthly blog-backfill retro start (target: ${PREV_MONTH_LOWER} ${PREV_YEAR}) ==="
 
+# --- Fail-loud guard: an early exit must never be silent ----------------------
+# This is one of the two scripts the "Nine Days Silent" postmortem was about: a
+# dirty-tree/worktree FATAL inside preflight_branch_normalize below EXITs before
+# the normal Slack + email path at the bottom, so the failure went unalerted.
+# Ported verbatim from blog-backfill-daily.sh: this trap fires on any non-zero
+# exit that bypassed the normal notification and pings Slack #cron-failures +
+# email. Clean exits (rc=0, incl. the idempotency no-op) and the normal path
+# (NOTIFIED=1) are skipped.
+NOTIFIED=0
+notify_unexpected_exit() {
+  local rc=$?
+  [ "$rc" -eq 0 ] && return
+  [ "$NOTIFIED" -eq 1 ] && return
+  log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"
+  slack_fail "blog-monthly-retro" "${PREV_MONTH_LOWER^} ${PREV_YEAR}: early exit rc=${rc} — NO retro. Check ${LOG}"
+  node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
+    --subject "🚨 blog-monthly-retro aborted early: ${PREV_MONTH_LOWER^} ${PREV_YEAR} (rc=${rc})" \
+    --body "$(printf 'Monthly blog retro exited abnormally (rc=%s) BEFORE its normal summary email.\n\nNo retro was produced for %s %s.\n\nLast 30 log lines:\n--------------------------------------------------------------------------------\n%s\n' "$rc" "${PREV_MONTH_LOWER^}" "$PREV_YEAR" "$(tail -30 "$LOG" 2>/dev/null)")" \
+    >/dev/null 2>&1 || true
+}
+trap notify_unexpected_exit EXIT
+
 # Idempotency: skip if last month's retro already exists
 if [ -f "$RETRO_FILE" ]; then
   log "Retro already exists at $RETRO_FILE — skipping (no-op)."
+  NOTIFIED=1
   exit 0
 fi
 
@@ -126,4 +155,6 @@ SUBJECT="${ESCALATE_PREFIX}Monthly blog retro: ${PREV_MONTH_LOWER^} ${PREV_YEAR}
 node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body "$BODY" >> "$LOG" 2>&1 \
   || log "Email send failed — see log"
 
+# Normal notification path completed — disarm the fail-loud trap.
+NOTIFIED=1
 log "=== Monthly blog-backfill retro end ==="

--- a/scripts/blog/blog-team-rollup.sh
+++ b/scripts/blog/blog-team-rollup.sh
@@ -22,6 +22,13 @@ set -uo pipefail
 
 LOG_DIR=/home/jeremy/.local/state/blog-team-rollup
 mkdir -p "$LOG_DIR"
+
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; the fail-loud trap below covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-team-rollup.beat" 2>/dev/null || true
+
 TODAY=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/run-${TODAY}.log"
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs

--- a/scripts/blog/blog-tier-creep-guard.sh
+++ b/scripts/blog/blog-tier-creep-guard.sh
@@ -22,6 +22,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
 
 LOG_DIR=/home/jeremy/.local/state/blog-tier-creep-guard
 mkdir -p "$LOG_DIR"
+
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; fail-alerting covers "ran but failed". Silence is
+# never valid on this tripwire — even a healthy (rc=0, no-alert) week must beat.
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-tier-creep-guard.beat" 2>/dev/null || true
+
 TS=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/guard-${TS}.log"
 GUARD=/home/jeremy/000-projects/blog/startaitools/.claude/skills/blog-backfill/scripts/tier-creep-guard.py
@@ -32,6 +40,9 @@ log "=== tier-creep-guard start ==="
 
 if [ ! -f "$GUARD" ]; then
   log "FATAL: $GUARD not found"
+  # Fail loud: this early FATAL previously bypassed slack_fail, silently no-oping
+  # the weekly tripwire (a missing guard means NO distribution check ran at all).
+  slack_fail "blog-tier-creep-guard" "${TS}: FATAL — guard script missing (${GUARD}); weekly tier tripwire did NOT run. Check ${LOG}"
   exit 1
 fi
 

--- a/scripts/blog/web-analytics-daily.sh
+++ b/scripts/blog/web-analytics-daily.sh
@@ -24,6 +24,12 @@ set -uo pipefail
 LOG_DIR=/home/jeremy/.local/state/web-analytics-daily
 mkdir -p "$LOG_DIR"
 
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; the fail-loud trap below covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/web-analytics-daily.beat" 2>/dev/null || true
+
 TODAY=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/run-${TODAY}.log"
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs


### PR DESCRIPTION
## Harden fail-alerting in the blog cron suite

A 2026-07-09 estate audit found that several `scripts/blog/` cron wrappers have an
early **FATAL path that `exit`s BEFORE reaching their own Slack/email notification
code** — so a failure is silent. (None use `set -e`; they use `set -uo pipefail`, so
there is no errexit-crash bug — this is a different, notification-bypass class.) The
reference for the correct pattern is `blog-backfill-daily.sh`, which installs a
catch-all `EXIT` trap (`NOTIFIED=0` + `notify_unexpected_exit` + `trap ... EXIT`) that
fires `slack_fail` on any abnormal exit. This PR ports that pattern to the scripts that
were missing it, plus wires estate liveness heartbeats.

### Fixes

1. **`blog-monthly-calibrate.sh` + `blog-monthly-retro.sh` (HIGH)** — the exact two
   scripts the "Nine Days Silent" postmortem was about. Both call the FATAL-capable
   `preflight_branch_normalize` with **no** catch-all trap, so a dirty-tree/worktree
   FATAL exited with zero Slack and zero email. Ported the `NOTIFIED`/
   `notify_unexpected_exit`/`trap ... EXIT` block verbatim from `blog-backfill-daily.sh`,
   installed right after the start-log line and **before** the first
   `preflight_branch_normalize` call; `NOTIFIED=1` on the normal path (and retro's
   idempotency no-op) keeps success/clean-skip silent.

2. **`blog-feedback-sweep.sh` (HIGH)** — had ZERO Slack fail-alerting on any path (never
   sourced `lib-cron-common.sh`, never called `slack_fail`, only a best-effort email
   whose own failure was merely logged). Now sources the lib and installs the same
   catch-all trap **before** the not-executable FATAL check, so that FATAL pages.

3. **`blog-tier-creep-guard.sh` (MEDIUM)** — its one early FATAL (guard script missing)
   logged "FATAL" and exited 1 with no `slack_fail`, silently no-oping the weekly
   tripwire. Added a direct `slack_fail` in that branch (the lib is already sourced).
   Kept surgical rather than adding a full email-sending trap onto a script whose
   healthy path is intentionally silent (hysteresis).

4. **Liveness heartbeats (HIGH)** — the estate dead-man's-switch
   (`~/bin/automation-liveness-sweep.sh`) only tracked 1 of the 8 blog cron jobs. Every
   wrapper now drops a per-run beat at `$HOME/.local/state/notify-lib/<job>.beat` near
   the top (`mkdir -p` + `: > <beat>`), before any preflight/FATAL, so the beat marks
   "the schedule fired" even on a run that then fails. `blog-posting-packet` already did
   this via notify-lib's `arm_fail_trap` and is unchanged.

### Heartbeat ROWS to register on the dev-box side

`~/bin/automation-liveness-sweep.sh` lives outside this repo — the dev-box owner
registers these ROWS. Beat dir: `$HOME/.local/state/notify-lib/`.

| Job | Beat file | Cadence | Cron schedule |
|---|---|---|---|
| `blog-backfill-daily` | `blog-backfill-daily.beat` | daily | `0 4 * * *` |
| `web-analytics-daily` | `web-analytics-daily.beat` | daily | `30 6 * * *` |
| `blog-posting-packet` | `blog-posting-packet.beat` | daily | `0 5 * * *` (already beats via `arm_fail_trap`) |
| `blog-team-rollup` | `blog-team-rollup.beat` | weekly (Mon) | `0 8 * * 1` |
| `blog-feedback-sweep` | `blog-feedback-sweep.beat` | weekly (Sun) | `0 10 * * 0` |
| `blog-tier-creep-guard` | `blog-tier-creep-guard.beat` | weekly (Sun) | `0 11 * * 0` |
| `blog-monthly-calibrate` | `blog-monthly-calibrate.beat` | monthly | `0 9 1 * *` |
| `blog-monthly-retro` | `blog-monthly-retro.beat` | monthly | `30 9 1 * *` |

### Verification

- `bash -n` passes on all 7 edited scripts.
- `shellcheck -S warning` clean on all 7.
- No script was executed (no posting, no git commits from the scripts, no Slack fired).

### Files changed

- `scripts/blog/blog-monthly-calibrate.sh`
- `scripts/blog/blog-monthly-retro.sh`
- `scripts/blog/blog-feedback-sweep.sh`
- `scripts/blog/blog-tier-creep-guard.sh`
- `scripts/blog/blog-backfill-daily.sh`
- `scripts/blog/web-analytics-daily.sh`
- `scripts/blog/blog-team-rollup.sh`
