### PR TITLE
feat(blog-cron): arm all 8 blog crons with two-marker liveness (.beat + .ok) — supersedes #25

### DIFF
--- a/.claude/skills/blog-backfill/scripts/tier-creep-guard.py
+++ b/.claude/skills/blog-backfill/scripts/tier-creep-guard.py
@@ -40,10 +40,12 @@ STATE_PATH = os.environ.get(
 )
 WINDOW = int(os.environ.get("TIER_CREEP_WINDOW", "30"))          # rolling sample size
 MIN_N = int(os.environ.get("TIER_CREEP_MIN_N", "10"))            # too-small-to-judge floor
-WORSEN_MARGIN = int(os.environ.get("TIER_CREEP_WORSEN_MARGIN", "5"))  # pts past high-water to re-alert
+# pts past high-water to re-alert
+WORSEN_MARGIN = int(os.environ.get("TIER_CREEP_WORSEN_MARGIN", "5"))
 
 # tolerance bands (percentages). Target: T1 60-70 / T2 25-35 / T3 5-10.
-# Each band: (metric key, direction). direction "high" = worse when larger; "low" = worse when smaller.
+# Each band: (metric key, direction). direction "high" = worse when larger;
+# "low" = worse when smaller.
 BANDS = {
     "t2_high": ("t2", "high", int(os.environ.get("TIER_CREEP_T2_HIGH", "40"))),  # T2 inflation
     "t1_low":  ("t1", "low",  int(os.environ.get("TIER_CREEP_T1_LOW", "52"))),   # T1 starved

--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -49,6 +49,7 @@ log "=== Daily blog-backfill start (target: $YESTERDAY) ==="
 NOTIFIED=0
 notify_unexpected_exit() {
   local rc=$?
+  liveness_markers "blog-backfill-daily" "$rc"   # .beat every run; .ok iff rc==0
   [ "$rc" -eq 0 ] && return
   [ "$NOTIFIED" -eq 1 ] && return
   log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"

--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -175,3 +175,9 @@ node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body 
 # Normal notification path completed — disarm the fail-loud trap.
 NOTIFIED=1
 log "=== Daily blog-backfill end ==="
+
+# Exit truthfully for the liveness trap (review finding on PR #26): a handled
+# failure must still exit non-zero so the EXIT trap withholds .ok and the estate
+# sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
+# trap does NOT double-alert.
+case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -20,6 +20,12 @@ set -uo pipefail
 LOG_DIR=/home/jeremy/.local/state/blog-backfill-daily
 mkdir -p "$LOG_DIR"
 
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; the fail-loud trap below covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-backfill-daily.beat" 2>/dev/null || true
+
 YESTERDAY=$(date -d "yesterday" +%Y-%m-%d)
 LOG="$LOG_DIR/run-${YESTERDAY}.log"
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs

--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -180,4 +180,4 @@ log "=== Daily blog-backfill end ==="
 # failure must still exit non-zero so the EXIT trap withholds .ok and the estate
 # sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
 # trap does NOT double-alert.
-case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac
+case "$STATUS" in OK*) : ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-feedback-sweep.sh
+++ b/scripts/blog/blog-feedback-sweep.sh
@@ -40,6 +40,7 @@ log "=== feedback-sweep start ==="
 NOTIFIED=0
 notify_unexpected_exit() {
   local rc=$?
+  liveness_markers "blog-feedback-sweep" "$rc"   # .beat every run; .ok iff rc==0
   [ "$rc" -eq 0 ] && return
   [ "$NOTIFIED" -eq 1 ] && return
   log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"

--- a/scripts/blog/blog-feedback-sweep.sh
+++ b/scripts/blog/blog-feedback-sweep.sh
@@ -10,13 +10,46 @@ set -uo pipefail
 
 LOG_DIR=/home/jeremy/.local/state/blog-feedback-sweep
 mkdir -p "$LOG_DIR"
+
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; fail-alerting (below) covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-feedback-sweep.beat" 2>/dev/null || true
+
 TS=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/sweep-${TS}.log"
 SCRIPT=/home/jeremy/000-projects/blog/startaitools/.claude/skills/blog-backfill/scripts/feedback-sweep.py
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs
 
+# Shared helper: slack_fail (posts failures to #cron-failures). Side-effect-free
+# at source time — defines functions only.
+# shellcheck source=./lib-cron-common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
+
 log() { echo "[$(date -Is)] $*" | tee -a "$LOG"; }
 log "=== feedback-sweep start ==="
+
+# --- Fail-loud guard: an early exit must never be silent ----------------------
+# Before this trap the only alerting was a best-effort email whose own failure
+# was merely logged — the FATAL below (feedback-sweep.py missing/not executable)
+# EXITed with ZERO Slack alert. Ported from blog-backfill-daily.sh: this fires on
+# any non-zero exit that bypassed the normal notification and pings Slack
+# #cron-failures + email. Clean exits (rc=0) and the normal path (NOTIFIED=1) are
+# skipped.
+NOTIFIED=0
+notify_unexpected_exit() {
+  local rc=$?
+  [ "$rc" -eq 0 ] && return
+  [ "$NOTIFIED" -eq 1 ] && return
+  log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"
+  slack_fail "blog-feedback-sweep" "${TS}: early exit rc=${rc} — sweep did not complete. Check ${LOG}"
+  node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
+    --subject "🚨 blog-feedback-sweep aborted early: ${TS} (rc=${rc})" \
+    --body "$(printf 'Weekly blog feedback-sweep exited abnormally (rc=%s) BEFORE its normal summary email.\n\nNo digest was sent for %s.\n\nLast 30 log lines:\n--------------------------------------------------------------------------------\n%s\n' "$rc" "$TS" "$(tail -30 "$LOG" 2>/dev/null)")" \
+    >/dev/null 2>&1 || true
+}
+trap notify_unexpected_exit EXIT
 
 if [ ! -x "$SCRIPT" ]; then
   log "FATAL: $SCRIPT not executable"
@@ -74,4 +107,6 @@ SUBJECT="Weekly blog feedback-sweep: ${TS} — ${STATUS}"
 node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body "$BODY" >> "$LOG" 2>&1 \
   || log "Email send failed — digest preserved in log"
 
+# Normal notification path completed — disarm the fail-loud trap.
+NOTIFIED=1
 log "=== feedback-sweep end ==="

--- a/scripts/blog/blog-feedback-sweep.sh
+++ b/scripts/blog/blog-feedback-sweep.sh
@@ -111,3 +111,9 @@ node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body 
 # Normal notification path completed — disarm the fail-loud trap.
 NOTIFIED=1
 log "=== feedback-sweep end ==="
+
+# Exit truthfully for the liveness trap (review finding on PR #26): a handled
+# failure must still exit non-zero so the EXIT trap withholds .ok and the estate
+# sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
+# trap does NOT double-alert.
+case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-feedback-sweep.sh
+++ b/scripts/blog/blog-feedback-sweep.sh
@@ -116,4 +116,4 @@ log "=== feedback-sweep end ==="
 # failure must still exit non-zero so the EXIT trap withholds .ok and the estate
 # sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
 # trap does NOT double-alert.
-case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac
+case "$STATUS" in OK*) : ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-monthly-calibrate.sh
+++ b/scripts/blog/blog-monthly-calibrate.sh
@@ -158,4 +158,4 @@ log "=== Monthly calibration end ==="
 # failure must still exit non-zero so the EXIT trap withholds .ok and the estate
 # sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
 # trap does NOT double-alert.
-case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac
+case "$STATUS" in OK*) : ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-monthly-calibrate.sh
+++ b/scripts/blog/blog-monthly-calibrate.sh
@@ -153,3 +153,9 @@ fi
 # Normal notification path completed — disarm the fail-loud trap.
 NOTIFIED=1
 log "=== Monthly calibration end ==="
+
+# Exit truthfully for the liveness trap (review finding on PR #26): a handled
+# failure must still exit non-zero so the EXIT trap withholds .ok and the estate
+# sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
+# trap does NOT double-alert.
+case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-monthly-calibrate.sh
+++ b/scripts/blog/blog-monthly-calibrate.sh
@@ -8,6 +8,12 @@ LOG_DIR=/home/jeremy/.local/state/blog-monthly-calibrate
 LOG="$LOG_DIR/calibrate.log"
 mkdir -p "$LOG_DIR"
 
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; fail-alerting (below) covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-monthly-calibrate.beat" 2>/dev/null || true
+
 # Shared helpers: preflight_branch_normalize, count_consecutive_failures.
 # shellcheck source=./lib-cron-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
@@ -20,6 +26,27 @@ BLOG_DIR=/home/jeremy/000-projects/blog/startaitools
 
 log() { echo "[$(date -Is)] $*" | tee -a "$LOG" "$PER_RUN_LOG"; }
 log "=== Monthly calibration start (target: $YM) ==="
+
+# --- Fail-loud guard: an early exit must never be silent ----------------------
+# This is one of the two scripts the "Nine Days Silent" postmortem was about: a
+# dirty-tree/worktree FATAL inside preflight_branch_normalize below EXITs before
+# the normal Slack + email path at the bottom, so the failure went unalerted.
+# Ported verbatim from blog-backfill-daily.sh: this trap fires on any non-zero
+# exit that bypassed the normal notification and pings Slack #cron-failures +
+# email. Clean exits (rc=0) and the normal path (NOTIFIED=1) are skipped.
+NOTIFIED=0
+notify_unexpected_exit() {
+  local rc=$?
+  [ "$rc" -eq 0 ] && return
+  [ "$NOTIFIED" -eq 1 ] && return
+  log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"
+  slack_fail "blog-monthly-calibrate" "${YM}: early exit rc=${rc} — NO calibration report. Check ${LOG}"
+  node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
+    --subject "🚨 blog-monthly-calibrate aborted early: ${YM} (rc=${rc})" \
+    --body "$(printf 'Monthly blog calibration exited abnormally (rc=%s) BEFORE its normal summary email.\n\nNo calibration report was produced for %s.\n\nLast 30 log lines:\n--------------------------------------------------------------------------------\n%s\n' "$rc" "$YM" "$(tail -30 "$LOG" 2>/dev/null)")" \
+    >/dev/null 2>&1 || true
+}
+trap notify_unexpected_exit EXIT
 
 # Pre-flight: clean tree, switch to default branch (pivot if held in a sibling
 # worktree), fast-forward. Same helper the daily uses.
@@ -122,4 +149,6 @@ else
   log "EMAIL FAILED — report kept at $REPORT"
 fi
 
+# Normal notification path completed — disarm the fail-loud trap.
+NOTIFIED=1
 log "=== Monthly calibration end ==="

--- a/scripts/blog/blog-monthly-calibrate.sh
+++ b/scripts/blog/blog-monthly-calibrate.sh
@@ -37,6 +37,7 @@ log "=== Monthly calibration start (target: $YM) ==="
 NOTIFIED=0
 notify_unexpected_exit() {
   local rc=$?
+  liveness_markers "blog-monthly-calibrate" "$rc"   # .beat every run; .ok iff rc==0
   [ "$rc" -eq 0 ] && return
   [ "$NOTIFIED" -eq 1 ] && return
   log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"

--- a/scripts/blog/blog-monthly-retro.sh
+++ b/scripts/blog/blog-monthly-retro.sh
@@ -13,6 +13,12 @@ set -uo pipefail
 LOG_DIR=/home/jeremy/.local/state/blog-monthly-retro
 mkdir -p "$LOG_DIR"
 
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; fail-alerting (below) covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-monthly-retro.beat" 2>/dev/null || true
+
 # Shared helpers: preflight_branch_normalize, count_consecutive_failures.
 # shellcheck source=./lib-cron-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
@@ -33,9 +39,32 @@ RETRO_FILE="$BLOG_DIR/content/monthly-recaps/${PREV_MONTH_LOWER}-${PREV_YEAR}.md
 log() { echo "[$(date -Is)] $*" | tee -a "$LOG"; }
 log "=== Monthly blog-backfill retro start (target: ${PREV_MONTH_LOWER} ${PREV_YEAR}) ==="
 
+# --- Fail-loud guard: an early exit must never be silent ----------------------
+# This is one of the two scripts the "Nine Days Silent" postmortem was about: a
+# dirty-tree/worktree FATAL inside preflight_branch_normalize below EXITs before
+# the normal Slack + email path at the bottom, so the failure went unalerted.
+# Ported verbatim from blog-backfill-daily.sh: this trap fires on any non-zero
+# exit that bypassed the normal notification and pings Slack #cron-failures +
+# email. Clean exits (rc=0, incl. the idempotency no-op) and the normal path
+# (NOTIFIED=1) are skipped.
+NOTIFIED=0
+notify_unexpected_exit() {
+  local rc=$?
+  [ "$rc" -eq 0 ] && return
+  [ "$NOTIFIED" -eq 1 ] && return
+  log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"
+  slack_fail "blog-monthly-retro" "${PREV_MONTH_LOWER^} ${PREV_YEAR}: early exit rc=${rc} — NO retro. Check ${LOG}"
+  node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
+    --subject "🚨 blog-monthly-retro aborted early: ${PREV_MONTH_LOWER^} ${PREV_YEAR} (rc=${rc})" \
+    --body "$(printf 'Monthly blog retro exited abnormally (rc=%s) BEFORE its normal summary email.\n\nNo retro was produced for %s %s.\n\nLast 30 log lines:\n--------------------------------------------------------------------------------\n%s\n' "$rc" "${PREV_MONTH_LOWER^}" "$PREV_YEAR" "$(tail -30 "$LOG" 2>/dev/null)")" \
+    >/dev/null 2>&1 || true
+}
+trap notify_unexpected_exit EXIT
+
 # Idempotency: skip if last month's retro already exists
 if [ -f "$RETRO_FILE" ]; then
   log "Retro already exists at $RETRO_FILE — skipping (no-op)."
+  NOTIFIED=1
   exit 0
 fi
 
@@ -126,4 +155,6 @@ SUBJECT="${ESCALATE_PREFIX}Monthly blog retro: ${PREV_MONTH_LOWER^} ${PREV_YEAR}
 node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body "$BODY" >> "$LOG" 2>&1 \
   || log "Email send failed — see log"
 
+# Normal notification path completed — disarm the fail-loud trap.
+NOTIFIED=1
 log "=== Monthly blog-backfill retro end ==="

--- a/scripts/blog/blog-monthly-retro.sh
+++ b/scripts/blog/blog-monthly-retro.sh
@@ -159,3 +159,9 @@ node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io --subject "$SUBJECT" --body 
 # Normal notification path completed — disarm the fail-loud trap.
 NOTIFIED=1
 log "=== Monthly blog-backfill retro end ==="
+
+# Exit truthfully for the liveness trap (review finding on PR #26): a handled
+# failure must still exit non-zero so the EXIT trap withholds .ok and the estate
+# sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
+# trap does NOT double-alert.
+case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-monthly-retro.sh
+++ b/scripts/blog/blog-monthly-retro.sh
@@ -164,4 +164,4 @@ log "=== Monthly blog-backfill retro end ==="
 # failure must still exit non-zero so the EXIT trap withholds .ok and the estate
 # sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
 # trap does NOT double-alert.
-case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac
+case "$STATUS" in OK*) : ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-monthly-retro.sh
+++ b/scripts/blog/blog-monthly-retro.sh
@@ -50,6 +50,7 @@ log "=== Monthly blog-backfill retro start (target: ${PREV_MONTH_LOWER} ${PREV_Y
 NOTIFIED=0
 notify_unexpected_exit() {
   local rc=$?
+  liveness_markers "blog-monthly-retro" "$rc"   # .beat every run; .ok iff rc==0
   [ "$rc" -eq 0 ] && return
   [ "$NOTIFIED" -eq 1 ] && return
   log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"

--- a/scripts/blog/blog-team-rollup.sh
+++ b/scripts/blog/blog-team-rollup.sh
@@ -138,3 +138,9 @@ fi
 rm -f "$OUTPUT_HTML" 2>/dev/null || true
 NOTIFIED=1
 log "=== Weekly team rollup end (${STATUS}) ==="
+
+# Exit truthfully for the liveness trap (review finding on PR #26): a handled
+# failure must still exit non-zero so the EXIT trap withholds .ok and the estate
+# sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
+# trap does NOT double-alert.
+case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-team-rollup.sh
+++ b/scripts/blog/blog-team-rollup.sh
@@ -22,6 +22,13 @@ set -uo pipefail
 
 LOG_DIR=/home/jeremy/.local/state/blog-team-rollup
 mkdir -p "$LOG_DIR"
+
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; the fail-loud trap below covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-team-rollup.beat" 2>/dev/null || true
+
 TODAY=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/run-${TODAY}.log"
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs

--- a/scripts/blog/blog-team-rollup.sh
+++ b/scripts/blog/blog-team-rollup.sh
@@ -143,4 +143,4 @@ log "=== Weekly team rollup end (${STATUS}) ==="
 # failure must still exit non-zero so the EXIT trap withholds .ok and the estate
 # sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
 # trap does NOT double-alert.
-case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac
+case "$STATUS" in OK*) : ;; *) exit 1 ;; esac

--- a/scripts/blog/blog-team-rollup.sh
+++ b/scripts/blog/blog-team-rollup.sh
@@ -53,6 +53,7 @@ log "Team recipients: $TEAM_EMAILS"
 NOTIFIED=0
 notify_unexpected_exit() {
   local rc=$?
+  liveness_markers "blog-team-rollup" "$rc"   # .beat every run; .ok iff rc==0
   [ "$rc" -eq 0 ] && return
   [ "$NOTIFIED" -eq 1 ] && return
   log "ABNORMAL EXIT (rc=$rc) before normal notification — fail-loud alert"

--- a/scripts/blog/blog-tier-creep-guard.sh
+++ b/scripts/blog/blog-tier-creep-guard.sh
@@ -22,6 +22,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib-cron-common.sh"
 
 LOG_DIR=/home/jeremy/.local/state/blog-tier-creep-guard
 mkdir -p "$LOG_DIR"
+
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; fail-alerting covers "ran but failed". Silence is
+# never valid on this tripwire — even a healthy (rc=0, no-alert) week must beat.
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/blog-tier-creep-guard.beat" 2>/dev/null || true
+
 TS=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/guard-${TS}.log"
 GUARD=/home/jeremy/000-projects/blog/startaitools/.claude/skills/blog-backfill/scripts/tier-creep-guard.py
@@ -32,6 +40,9 @@ log "=== tier-creep-guard start ==="
 
 if [ ! -f "$GUARD" ]; then
   log "FATAL: $GUARD not found"
+  # Fail loud: this early FATAL previously bypassed slack_fail, silently no-oping
+  # the weekly tripwire (a missing guard means NO distribution check ran at all).
+  slack_fail "blog-tier-creep-guard" "${TS}: FATAL — guard script missing (${GUARD}); weekly tier tripwire did NOT run. Check ${LOG}"
   exit 1
 fi
 

--- a/scripts/blog/blog-tier-creep-guard.sh
+++ b/scripts/blog/blog-tier-creep-guard.sh
@@ -30,6 +30,11 @@ mkdir -p "$LOG_DIR"
 mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
 : > "$HOME/.local/state/notify-lib/blog-tier-creep-guard.beat" 2>/dev/null || true
 
+# Health marker: on exit, beat again and write <job>.ok iff this run ended
+# rc==0 (two-marker protocol — see lib-cron-common.sh:liveness_markers). This
+# script has no other EXIT trap; the trap-string `$?` expands at exit time.
+trap 'liveness_markers "blog-tier-creep-guard" "$?"' EXIT
+
 TS=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/guard-${TS}.log"
 GUARD=/home/jeremy/000-projects/blog/startaitools/.claude/skills/blog-backfill/scripts/tier-creep-guard.py

--- a/scripts/blog/blog-tier-creep-guard.sh
+++ b/scripts/blog/blog-tier-creep-guard.sh
@@ -96,3 +96,11 @@ Guard: ${GUARD}
 esac
 
 log "=== tier-creep-guard end (rc=$RC) ==="
+
+# Exit truthfully for the liveness trap (review finding on PR #26): a guard
+# ERROR (rc>=2 — the distribution was never evaluated) exits non-zero so the
+# EXIT trap withholds .ok. A breach alert (rc=1) or recovery (rc=3) is the
+# tripwire WORKING — the automation is healthy even when the content isn't —
+# so those exit 0. (The estate sweep monitors automation health, not content.)
+if [ "$RC" -ge 2 ] && [ "$RC" -ne 3 ]; then exit 1; fi
+exit 0

--- a/scripts/blog/blog-tier-creep-guard.sh
+++ b/scripts/blog/blog-tier-creep-guard.sh
@@ -103,4 +103,3 @@ log "=== tier-creep-guard end (rc=$RC) ==="
 # tripwire WORKING — the automation is healthy even when the content isn't —
 # so those exit 0. (The estate sweep monitors automation health, not content.)
 if [ "$RC" -ge 2 ] && [ "$RC" -ne 3 ]; then exit 1; fi
-exit 0

--- a/scripts/blog/lib-cron-common.sh
+++ b/scripts/blog/lib-cron-common.sh
@@ -176,6 +176,37 @@ slack_fail() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# liveness_markers <job> <rc>
+#
+# Two-marker estate liveness/health protocol (2026-07-10; mirrors
+# ~/bin/lib/notify-lib.sh:_nl_on_exit). Touches, under
+# $HOME/.local/state/notify-lib/:
+#   <job>.beat  on EVERY call        — "the schedule fired" (liveness)
+#   <job>.ok    ONLY when <rc> is 0  — "and the run succeeded" (health)
+# The estate dead-man's-switch (~/bin/automation-liveness-sweep.sh) reads the
+# pair: stale .beat = stopped running; fresh .beat + stale/missing .ok =
+# running-but-failing. A failure run must NOT touch .ok — that gap IS the
+# signal, so never call this with a forged rc.
+#
+# Call it from the wrapper's EXIT trap, immediately after `local rc=$?`, so the
+# markers land on every exit path. The raw top-of-script beat drop each wrapper
+# carries still covers a crash BEFORE the trap is armed (and is intentionally
+# lib-independent so a broken source line can't hide a run). Never fails the
+# caller.
+# ─────────────────────────────────────────────────────────────────────────────
+liveness_markers() {
+  local job="$1" rc="${2:-1}"
+  local dir="$HOME/.local/state/notify-lib"
+  local safe="${job//[^A-Za-z0-9_-]/_}"
+  mkdir -p "$dir" 2>/dev/null || true
+  : > "$dir/${safe}.beat" 2>/dev/null || true
+  if [ "$rc" = "0" ]; then
+    : > "$dir/${safe}.ok" 2>/dev/null || true
+  fi
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # default_branch_of <repo>
 #
 # Resolves the branch a repo publishes/deploys from, robustly. The old

--- a/scripts/blog/web-analytics-daily.sh
+++ b/scripts/blog/web-analytics-daily.sh
@@ -132,3 +132,9 @@ esac
 # Normal notification path completed — disarm the fail-loud trap.
 NOTIFIED=1
 log "=== Daily web-analytics email end (${STATUS}) ==="
+
+# Exit truthfully for the liveness trap (review finding on PR #26): a handled
+# failure must still exit non-zero so the EXIT trap withholds .ok and the estate
+# sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
+# trap does NOT double-alert.
+case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac

--- a/scripts/blog/web-analytics-daily.sh
+++ b/scripts/blog/web-analytics-daily.sh
@@ -137,4 +137,4 @@ log "=== Daily web-analytics email end (${STATUS}) ==="
 # failure must still exit non-zero so the EXIT trap withholds .ok and the estate
 # sweep's running-but-failing signal stays live. NOTIFIED=1 above guarantees the
 # trap does NOT double-alert.
-case "$STATUS" in OK*) exit 0 ;; *) exit 1 ;; esac
+case "$STATUS" in OK*) : ;; *) exit 1 ;; esac

--- a/scripts/blog/web-analytics-daily.sh
+++ b/scripts/blog/web-analytics-daily.sh
@@ -50,6 +50,7 @@ log "=== Daily web-analytics email start (tier: ${TIER}, target: ${TODAY}) ==="
 NOTIFIED=0
 notify_unexpected_exit() {
   local rc=$?
+  liveness_markers "web-analytics-daily" "$rc"   # .beat every run; .ok iff rc==0
   [ "$rc" -eq 0 ] && return
   [ "$NOTIFIED" -eq 1 ] && return
   log "ABNORMAL EXIT (rc=$rc) before normal notification — sending fail-loud alert"

--- a/scripts/blog/web-analytics-daily.sh
+++ b/scripts/blog/web-analytics-daily.sh
@@ -24,6 +24,12 @@ set -uo pipefail
 LOG_DIR=/home/jeremy/.local/state/web-analytics-daily
 mkdir -p "$LOG_DIR"
 
+# Liveness heartbeat: drop a per-run beat so the estate dead-man's-switch
+# (~/bin/automation-liveness-sweep.sh) can tell this schedule still fires. The
+# beat marks "the cron ran"; the fail-loud trap below covers "ran but failed".
+mkdir -p "$HOME/.local/state/notify-lib" 2>/dev/null || true
+: > "$HOME/.local/state/notify-lib/web-analytics-daily.beat" 2>/dev/null || true
+
 TODAY=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/run-${TODAY}.log"
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs


### PR DESCRIPTION
## What

Arms the full 8-job blog cron fleet with the estate's **two-marker liveness/health protocol**: every wrapper run touches `~/.local/state/notify-lib/<job>.beat` (liveness — "the schedule fired"), and `<job>.ok` is touched **only** on an rc==0 exit (health — "and it succeeded"). Builds ON TOP of PR #25 (its branch is merged into this one, all four of its fail-loud fixes retained) and supersedes it: #25 pre-dated the 2026-07-10 sweep upgrade and dropped `.beat` only, which leaves the running-but-failing blind spot open.

- `scripts/blog/lib-cron-common.sh` — new `liveness_markers <job> <rc>` helper (mirrors `~/bin/lib/notify-lib.sh:_nl_on_exit`).
- 6 wrappers with existing `notify_unexpected_exit` EXIT traps (`blog-backfill-daily`, `web-analytics-daily`, `blog-team-rollup`, `blog-feedback-sweep`, `blog-monthly-calibrate`, `blog-monthly-retro`) call it as the trap's first statement, before the rc==0/NOTIFIED early-returns.
- `blog-tier-creep-guard.sh` (no prior trap) arms `trap 'liveness_markers "blog-tier-creep-guard" "$?"' EXIT`.
- `blog-posting-packet.sh` untouched — already two-marker via `notify-lib:arm_fail_trap`.
- PR #25's raw top-of-script beat drops are **kept**: lib-independent, they cover a crash before the trap arms.

## Why + decision rationale

The estate dead-man's-switch (`~/bin/automation-liveness-sweep.sh`, dev-box local) was upgraded 2026-07-10 to read the marker **pair**: stale `.beat` = stopped running; fresh `.beat` + stale/missing `.ok` = running-but-failing — the exact failure class that hid a broken monitor for 15 days. A beat-only fleet cannot express the second state.

**Chose per-wrapper trap wiring over a lib-installed EXIT trap because** bash keeps exactly one EXIT trap per shell: a trap installed by the lib would silently clobber (or be clobbered by) each wrapper's `notify_unexpected_exit`, killing the fail-loud Slack/email path #25 just built.

**Root cause folded in (blog-backfill-daily missed beat, 2026-07-10):** the Jul 10 04:00 run *succeeded* (post published + verified live, log `run-2026-07-09.log` ends clean 04:30:10; the post commit is `0aee62de` at 04:28:33) yet advanced no beat — the instrumentation existed only on the unmerged #25 branch. Its Jul 9 beat fired only because the shared tree happened to be parked on that branch at 04:00 (reflog: checkout to the branch 00:25:40; the run's own `preflight_branch_normalize` switched it back to master at 04:00:03). Landing the instrumentation on master is the fix.

## Layer(s) touched

Cron wrapper layer only (`scripts/blog/`). No Hugo content, no CI config, no publisher logic. New invariant: every blog cron exit path emits `.beat`, and `.ok` moves only on success — a failure run must never touch `.ok`.

## How it works

`liveness_markers` sanitizes the job name (`[^A-Za-z0-9_-] -> _`, same rule as notify-lib), `mkdir -p`s the state dir, truncate-touches `.beat` always and `.ok` iff rc==0, and always returns 0 so it can never flip a wrapper's exit status or trip `set -e`. In the six trap wrappers it runs before the `rc==0`/`NOTIFIED` early-returns, so clean exits, no-op skips (retro idempotency, backfill lock/exists), and failures all mark correctly.

## Verification & evidence

- `bash -n`: all 8 files pass. `shellcheck -S warning`: clean on all 8.
- Sandbox-HOME functional test (fresh `$HOME`, sourced lib):
  - `liveness_markers fail-job 3` → `fail-job.beat` only (no `.ok`) ✓
  - `liveness_markers ok-job 0` → `ok-job.beat` + `ok-job.ok` ✓
  - trap-string form in a `set -uo pipefail` script exiting 5 → `trap-job.beat` only, and the script's observed rc stayed 5 ✓
- No blog script was executed end-to-end (no posting, no emails, no Slack fired).

## Risk assessment

Low. All marker writes are `2>/dev/null || true`-guarded truncate-touches of zero-byte state files outside the repo; a full/broken state dir cannot fail a cron. The one behavioral addition to a live path is one function call at trap entry. Worst case is a missing marker — which is exactly what the sweep alarms on.

## Operational impact — deployment topology (read this)

**Crontab invokes these scripts by direct repo path** (`/home/jeremy/000-projects/blog/startaitools/scripts/blog/*.sh`) — the runtime location IS the shared working tree, currently on `master`, clean. Deploy after merge = fast-forward that tree's `master` (`git pull --ff-only origin master`), which is the same operation `blog-backfill-daily`'s own preflight performs every run at 04:00. No crontab changes. No env/secret changes. The dev-box sweep registers the 8 rows separately (dev-box-local file, outside this repo — being done in the same estate task, bead OPS-lao.5).

Marker seeding: jobs that haven't run since instrumentation will be seeded (`.beat`+`.ok` touched, disclosed in the estate report) so the sweep doesn't false-alarm before each job's first natural run; dailies self-correct at their next 04:00/05:00/06:30 firings.

## Follow-up & deferred

- #25 will be closed as superseded (comment explains).
- `web-analytics-daily.sh`'s comment block still says "ntfy" in one place (pre-existing, cosmetic) — not touched to keep the diff surgical.

## Refs

Refs jeremylongshore/startaitools.com#25 (superseded)
Refs intent-solutions-io/intent-os#42