### PR TITLE
fix(blog-backfill): hard-ban em dashes and AI-slop voice lint

### DIFF
--- a/.claude/skills/blog-backfill/SKILL.md
+++ b/.claude/skills/blog-backfill/SKILL.md
@@ -153,12 +153,19 @@ This is **load-bearing**: the 2026-05-28 root-cause work depended on these marke
 
    | Gate | Tier 1 | Tier 2 | Tier 3 |
    |------|:------:|:------:|:------:|
+   | **Voice lint** (`scripts/lint-post-voice.py` — hard no em/en dash + AI-slop phrases) | ✓ | ✓ | ✓ |
    | Hugo build | ✓ | ✓ | ✓ |
    | `code-reviewer` agent (if code present) | ✓ | ✓ | ✓ |
    | `blog-consistency-checker` agent (skill-local, tier-aware) | — | ✓ | ✓ |
    | `article-consistency-checker` agent (global, second pair of eyes) | — | ✓ | ✓ |
    | `blog-fact-checker` agent (skill-local) | — | — | ✓ |
    | `fact-checker` agent (global) | — | — | ✓ |
+
+   **Voice lint (mandatory, all tiers, first after write):**  
+   ```bash
+   python3 "${CLAUDE_SKILL_DIR}/scripts/lint-post-voice.py" "content/posts/${SLUG}.md"
+   ```  
+   Exit non-zero = rewrite the draft (remove every em/en dash and banned phrase) and re-run until exit 0. Do **not** set `ready:true` while this fails. `blog-land.sh` re-runs the same lint and quarantines on failure. Historical posts are not bulk-rewritten; only the post being produced/landed is gated.
 
    If any agent returns `BLOCK`, revise the post and re-run the failing gate. `REVISE` suggestions are applied if confidence is high; otherwise flagged in the audit trail. `PASS` proceeds to step 6.
 
@@ -278,6 +285,8 @@ Generates the previous month's retrospective with velocity dashboard, tier distr
 - Front matter is TOML (`+++` delimiters)
 - All repos are local at `/home/jeremy/000-projects/` — no cloning needed
 - No mermaid diagrams — site never uses them
+- **Hard ban em dash (`—`) and en dash (`–`) in every new post** (title, description, headings, body). Prefer period/comma/colon/parens. Enforced by `scripts/lint-post-voice.py` + `blog-land.sh`.
+- No AI-slop phrases (see `references/write-post.md` forbidden list); same linter.
 - Hugo v0.150.0 locked in netlify.toml
 - Use `--buildFuture` in build commands
 - decisions.jsonl is append-only — never edit existing records

--- a/.claude/skills/blog-backfill/references/final-verification.md
+++ b/.claude/skills/blog-backfill/references/final-verification.md
@@ -7,7 +7,8 @@ After all posts are published, run through this checklist:
 1. `hugo --buildFuture --gc --minify --cleanDestinationDir` — clean production build for startaitools
 2. `cd /home/jeremy/000-projects/claude-code-plugins/marketplace && npm run build` — verify tonsofskills build
 3. Verify post count matches expected on both sites
-4. Spot-check 3 posts for: correct dates, working code blocks, no AI slop
+4. Spot-check 3 posts for: correct dates, working code blocks, no AI slop, no em/en dashes
+   (for any *new* post in the batch: `python3 ${CLAUDE_SKILL_DIR}/scripts/lint-post-voice.py content/posts/SLUG.md` must exit 0)
 
 ## Cross-Post & Social Verification
 

--- a/.claude/skills/blog-backfill/references/social-bundle.md
+++ b/.claude/skills/blog-backfill/references/social-bundle.md
@@ -13,14 +13,18 @@ people writing for different rooms — do not let them converge.
 
 - **X and LinkedIn must NOT share an opening sentence.** Different hook, different
   angle, every time. This is a hard fail if violated.
-- **Banned phrases — never use:** "excited to share", "thrilled to", "dive into",
+- **Banned phrases (never use):** "excited to share", "thrilled to", "dive into",
   "delve", "in today's fast-paced", "game-changer", "unlock", "leverage" (as a
-  verb), "revolutionize", "seamless", "supercharge". If a draft contains one,
-  rewrite it.
+  verb), "revolutionize", "seamless", "supercharge", "comprehensive",
+  "at its core", "in conclusion", "the landscape of", "navigate the",
+  "without further ado", "it goes without saying", "in this blog post",
+  "it's worth noting". If a draft contains one, rewrite it.
+- **Hard ban em dash and en dash** in all three voices (same rule as article prose).
+  Use period, comma, colon, or parens. Never Unicode em/en dash or HTML entities.
 - **No links in the copy.** Do not write `Deep-dive:`, `Code:`, `Read:`, or any URL
-  — the packet appends those. Hashtags are fine where noted.
+  (the packet appends those). Hashtags are fine where noted.
 - **No AI slop.** Concrete nouns, real specifics from the post, honest trade-offs.
-  If the post admits a limitation, the social copy can too — that's what earns trust.
+  If the post admits a limitation, the social copy can too; that earns trust.
 
 ## ① X / Twitter — the raw voice
 

--- a/.claude/skills/blog-backfill/references/write-post.md
+++ b/.claude/skills/blog-backfill/references/write-post.md
@@ -74,16 +74,41 @@ description = "SEO description under 160 chars"
 - Connect to the broader Intent Solutions narrative
 - Target audience: builders, Claude Code users, production systems engineers
 - End with 2-3 Related Posts cross-links to existing content
+- Prefer period, comma, colon, or parentheses for asides. Never a dash run-on.
 
-### Absolutely forbidden (AI slop)
+### Absolutely forbidden (AI slop + voice fingerprint)
 
-- "In this blog post"
-- "Let's dive in"
-- "It's worth noting"
-- "diving deep"
+**Hard ban: em dash and en dash.** Zero tolerance, everywhere in the file:
+title, description, headings, body, code comments you invent, Related Posts lines.
+Do not use `—` (U+2014), `–` (U+2013), or HTML `&mdash;` / `&ndash;`.
+Section titles: use a colon or a plain title (`## Disguise 1: empty args…`), never
+`## Title — subtitle`. Subtitles and meta description: same rule.
+
+If you are about to write an em dash, rewrite as two sentences or use parens.
+
+**Banned phrases** (case-insensitive; if any appear, rewrite before saving):
+
+- "In this blog post" / "In this article" / "In this post"
+- "Let's dive in" / "dive into" / "diving deep"
+- "It's worth noting" / "worth noting that"
+- "delve" / "delving"
 - "comprehensive"
+- "in today's fast-paced"
+- "game-changer" / "game changer"
+- "revolutionize" / "seamless" / "supercharge"
+- "excited to share" / "thrilled to"
+- "unlock the" / "leverage" (hype verb)
+- "at its core" / "in conclusion"
+- "the landscape of" / "navigate the"
+- "without further ado" / "it goes without saying"
 - Any mermaid diagrams (site never uses them)
 - Generic intros or outros
+- Emoji in titles or body
+
+**Enforcement:** after the draft is on disk, the main thread runs
+`${CLAUDE_SKILL_DIR}/scripts/lint-post-voice.py content/posts/SLUG.md`.
+Non-zero exit = rewrite until clean. `blog-land.sh` re-runs the same lint and
+**quarantines** (does not publish) on failure. CI lints changed posts on PRs.
 
 ---
 

--- a/.claude/skills/blog-backfill/references/writer-briefing-template.md
+++ b/.claude/skills/blog-backfill/references/writer-briefing-template.md
@@ -42,16 +42,32 @@ You are writing a Tier {{TIER}} blog post for startaitools.com. Write the comple
 - Connect to the broader Intent Solutions narrative
 - Target audience: builders, Claude Code users, production systems engineers
 - End with 2-3 Related Posts cross-links to existing content
+- Prefer period, comma, colon, or parentheses for asides. Never a dash run-on.
 
-FORBIDDEN PHRASES (AI slop):
-- "In this blog post"
-- "Let's dive in"
-- "It's worth noting"
-- "diving deep"
-- "comprehensive"
+HARD BAN: em dash and en dash (zero tolerance, whole file):
+- Never use the Unicode em dash (U+2014), en dash (U+2013), or HTML &mdash; / &ndash;
+- Titles, descriptions, H2/H3 subtitles, body: no exceptions
+- Section titles use colon or plain wording, never "Title" plus dash plus "subtitle"
+- If tempted to use an em dash, split into two sentences or use parens
+
+FORBIDDEN PHRASES (AI slop; case-insensitive; rewrite if any appear):
+- "In this blog post" / "In this article" / "In this post"
+- "Let's dive in" / "dive into" / "diving deep"
+- "It's worth noting" / "worth noting that"
+- "delve" / "delving" / "comprehensive"
+- "in today's fast-paced" / "game-changer" / "game changer"
+- "revolutionize" / "seamless" / "supercharge"
+- "excited to share" / "thrilled to"
+- "unlock the" / "leverage" (as hype verb)
+- "at its core" / "in conclusion"
+- "the landscape of" / "navigate the"
+- "without further ado" / "it goes without saying"
 - Any mermaid diagrams (site never uses them)
 - Generic intros or outros
 - Emoji in titles or body (the site voice is plain-direct)
+
+Voice lint (deterministic): after write, main thread runs
+lint-post-voice.py on this file and must exit 0 before quality gates finish.
 
 === TIER-{{TIER}} STRUCTURE RULES ===
 

--- a/.claude/skills/blog-backfill/scripts/lint-post-voice.py
+++ b/.claude/skills/blog-backfill/scripts/lint-post-voice.py
@@ -29,7 +29,7 @@ HTML_DASH_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Phrase patterns — word boundaries where applicable. Keep aligned with
+# Phrase patterns: word boundaries where applicable. Keep aligned with
 # write-post.md / writer-briefing-template.md / social-bundle.md.
 SLOP_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("in this blog post", re.compile(r"\bin this blog post\b", re.I)),
@@ -68,6 +68,22 @@ def _line_col(text: str, index: int) -> tuple[int, int]:
     return line, col
 
 
+def _mask_for_slop(text: str) -> str:
+    """Blank out fenced code, inline code, and URLs for phrase checks only.
+
+    Replaces matched spans with spaces of equal length so line/col offsets from
+    the original text stay valid. Em/en dash scanning still uses raw text.
+    """
+
+    def blank(m: re.Match[str]) -> str:
+        return " " * len(m.group(0))
+
+    cleaned = re.sub(r"```[\s\S]*?```", blank, text)
+    cleaned = re.sub(r"`[^`\n]+`", blank, cleaned)
+    cleaned = re.sub(r"https?://[^\s)>\]]+", blank, cleaned)
+    return cleaned
+
+
 def lint_text(text: str, path: str) -> list[str]:
     issues: list[str] = []
 
@@ -88,10 +104,14 @@ def lint_text(text: str, path: str) -> list[str]:
         issues.append(
             f"{path}:{line}:{col}: HTML dash entity {m.group()!r} hard ban"
         )
+
+    slop_text = _mask_for_slop(text)
     for label, pat in SLOP_PATTERNS:
-        for m in pat.finditer(text):
+        for m in pat.finditer(slop_text):
             line, col = _line_col(text, m.start())
-            issues.append(f"{path}:{line}:{col}: AI-slop phrase ({label}): {m.group()!r}")
+            # Report the original surface text (same offsets as slop_text).
+            surface = text[m.start() : m.end()]
+            issues.append(f"{path}:{line}:{col}: AI-slop phrase ({label}): {surface!r}")
 
     return issues
 
@@ -99,7 +119,7 @@ def lint_text(text: str, path: str) -> list[str]:
 def lint_file(path: Path) -> list[str]:
     try:
         text = path.read_text(encoding="utf-8")
-    except OSError as e:
+    except (OSError, UnicodeDecodeError) as e:
         return [f"{path}: IO error: {e}"]
     return lint_text(text, str(path))
 
@@ -128,7 +148,7 @@ def main(argv: list[str] | None = None) -> int:
             io_fail = True
             continue
         issues = lint_file(path)
-        if issues and issues[0].endswith("IO error:"):
+        if issues and ": IO error:" in issues[0]:
             print(issues[0], file=sys.stderr)
             io_fail = True
             continue

--- a/.claude/skills/blog-backfill/scripts/lint-post-voice.py
+++ b/.claude/skills/blog-backfill/scripts/lint-post-voice.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""lint-post-voice.py: hard fail on em/en dashes and banned AI-slop phrases.
+
+Gates NEW blog prose only (the daily produce -> land path). Does not rewrite
+history: callers pass specific post paths (the post being landed / PR-changed
+files). Exit 0 = clean, 1 = violations found, 2 = usage/IO error.
+
+Banned punctuation (hard no, anywhere in the file including title/description):
+  U+2014 em dash
+  U+2013 en dash
+  HTML entities &mdash; &ndash; &#8212; &#8211; &#x2014; &#x2013;
+
+Banned AI-slop phrases: case-insensitive whole-phrase / word-boundary matches.
+Keep this list in sync with references/write-post.md (Absolutely forbidden).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Unicode dashes
+EM = "\u2014"
+EN = "\u2013"
+
+HTML_DASH_RE = re.compile(
+    r"&(?:mdash|ndash);|&#(?:8212|8211);|&#x(?:2014|2013);",
+    re.IGNORECASE,
+)
+
+# Phrase patterns — word boundaries where applicable. Keep aligned with
+# write-post.md / writer-briefing-template.md / social-bundle.md.
+SLOP_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("in this blog post", re.compile(r"\bin this blog post\b", re.I)),
+    ("let's dive in", re.compile(r"\blet'?s dive in\b", re.I)),
+    ("dive into", re.compile(r"\bdive into\b", re.I)),
+    ("diving deep", re.compile(r"\bdiving deep\b", re.I)),
+    ("it's worth noting", re.compile(r"\bit'?s worth noting\b", re.I)),
+    ("worth noting that", re.compile(r"\bworth noting that\b", re.I)),
+    ("delve", re.compile(r"\bdelve[sd]?\b", re.I)),
+    ("delving", re.compile(r"\bdelving\b", re.I)),
+    ("in today's fast-paced", re.compile(r"\bin today'?s fast[- ]paced\b", re.I)),
+    ("game-changer", re.compile(r"\bgame[- ]changers?\b", re.I)),
+    ("revolutionize", re.compile(r"\brevolutioniz(?:e|es|ed|ing)\b", re.I)),
+    ("seamless", re.compile(r"\bseamless(?:ly)?\b", re.I)),
+    ("supercharge", re.compile(r"\bsupercharg(?:e|es|ed|ing)\b", re.I)),
+    ("excited to share", re.compile(r"\bexcited to share\b", re.I)),
+    ("thrilled to", re.compile(r"\bthrilled to\b", re.I)),
+    ("unlock", re.compile(r"\bunlock(?:s|ed|ing)? the\b", re.I)),
+    ("leverage (verb hype)", re.compile(r"\bleverag(?:e|es|ed|ing)\b", re.I)),
+    ("at its core", re.compile(r"\bat its core\b", re.I)),
+    ("in conclusion", re.compile(r"\bin conclusion\b", re.I)),
+    ("the landscape of", re.compile(r"\bthe landscape of\b", re.I)),
+    ("navigate the", re.compile(r"\bnavigate the\b", re.I)),
+    ("comprehensive", re.compile(r"\bcomprehensive\b", re.I)),
+    ("in this article", re.compile(r"\bin this article\b", re.I)),
+    ("in this post", re.compile(r"\bin this post\b", re.I)),
+    ("without further ado", re.compile(r"\bwithout further ado\b", re.I)),
+    ("it goes without saying", re.compile(r"\bit goes without saying\b", re.I)),
+]
+
+
+def _line_col(text: str, index: int) -> tuple[int, int]:
+    line = text.count("\n", 0, index) + 1
+    last_nl = text.rfind("\n", 0, index)
+    col = index - last_nl
+    return line, col
+
+
+def lint_text(text: str, path: str) -> list[str]:
+    issues: list[str] = []
+
+    for i, ch in enumerate(text):
+        if ch == EM:
+            line, col = _line_col(text, i)
+            issues.append(
+                f"{path}:{line}:{col}: em dash (U+2014) hard ban; use period/comma/colon/parens"
+            )
+        elif ch == EN:
+            line, col = _line_col(text, i)
+            issues.append(
+                f"{path}:{line}:{col}: en dash (U+2013) hard ban; use hyphen or rephrase"
+            )
+
+    for m in HTML_DASH_RE.finditer(text):
+        line, col = _line_col(text, m.start())
+        issues.append(
+            f"{path}:{line}:{col}: HTML dash entity {m.group()!r} hard ban"
+        )
+    for label, pat in SLOP_PATTERNS:
+        for m in pat.finditer(text):
+            line, col = _line_col(text, m.start())
+            issues.append(f"{path}:{line}:{col}: AI-slop phrase ({label}): {m.group()!r}")
+
+    return issues
+
+
+def lint_file(path: Path) -> list[str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return [f"{path}: IO error: {e}"]
+    return lint_text(text, str(path))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Markdown post path(s) to lint (new/changed posts only)",
+    )
+    parser.add_argument(
+        "--max-issues",
+        type=int,
+        default=50,
+        help="Cap printed issues per file (default 50); full count still reported",
+    )
+    args = parser.parse_args(argv)
+
+    any_fail = False
+    io_fail = False
+    for path in args.paths:
+        if not path.is_file():
+            print(f"{path}: not a file", file=sys.stderr)
+            io_fail = True
+            continue
+        issues = lint_file(path)
+        if issues and issues[0].endswith("IO error:"):
+            print(issues[0], file=sys.stderr)
+            io_fail = True
+            continue
+        if not issues:
+            print(f"OK: {path}")
+            continue
+        any_fail = True
+        print(f"FAIL: {path} ({len(issues)} issue(s))", file=sys.stderr)
+        for msg in issues[: args.max_issues]:
+            print(f"  {msg}", file=sys.stderr)
+        if len(issues) > args.max_issues:
+            print(f"  … +{len(issues) - args.max_issues} more", file=sys.stderr)
+
+    if io_fail:
+        return 2
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts-lint.yml
+++ b/.github/workflows/scripts-lint.yml
@@ -63,6 +63,34 @@ jobs:
           fi
           ruff check "${files[@]}"
 
+  # Voice lint on changed posts only (hard no em/en dash + AI-slop phrases).
+  # Full content/posts/ is NOT scanned: historical posts predate the ban and
+  # are intentionally left alone. Daily produce→land also runs this gate.
+  voice-lint-changed-posts:
+    name: voice-lint (changed posts)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Lint changed content/posts/*.md
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$BASE"...HEAD -- 'content/posts/*.md' || true)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "no changed content/posts/*.md — skipping"
+            exit 0
+          fi
+          python3 .claude/skills/blog-backfill/scripts/lint-post-voice.py "${files[@]}"
+
   hugo-build-check:
     name: hugo build (PR only)
     # Skip on push-to-master since Netlify is the canonical builder there.

--- a/scripts/blog/blog-land.sh
+++ b/scripts/blog/blog-land.sh
@@ -168,7 +168,20 @@ grep -q "\"date\"[[:space:]]*:[[:space:]]*\"$TARGET_DATE\"" "$DECISIONS" 2>/dev/
 grep "\"slug\"[[:space:]]*:[[:space:]]*\"$SLUG\"" "$DECISIONS" 2>/dev/null | grep -q 'audit_addendum' \
   || REASONS+=("no agent_audit addendum for $SLUG (step 8 skipped)")
 
-# (4) Hugo build must pass (catches broken front matter / bad shortcodes).
+# (4) Voice lint: hard no em/en dash + banned AI-slop phrases (new posts only).
+# Historical posts are not bulk-rewritten; this gates the post being landed.
+VOICE_LINT="$BLOG_DIR/.claude/skills/blog-backfill/scripts/lint-post-voice.py"
+if [ -f "$VOICE_LINT" ] && [ -f "$POST" ]; then
+  if python3 "$VOICE_LINT" "$POST" >> "$LOG" 2>&1; then
+    log "Voice lint OK"
+  else
+    REASONS+=("voice lint failed (em/en dash or AI-slop phrase in $POST_REL; see log)")
+  fi
+else
+  log "WARN: voice lint script or post missing; skipping voice gate"
+fi
+
+# (5) Hugo build must pass (catches broken front matter / bad shortcodes).
 if hugo --buildFuture --gc --minify --cleanDestinationDir --quiet >> "$LOG" 2>&1; then
   log "Hugo build OK"
 else
@@ -225,7 +238,7 @@ fi
 
 # ---- Land: commit + push (canonical) ---------------------------------------
 git add "$POST_REL" ".claude/skills/blog-backfill/methodology/decisions.jsonl"
-if git commit --no-verify -m "post(${TARGET_DATE}): ${TITLE} — Tier ${TIER}" >> "$LOG" 2>&1; then
+if git commit --no-verify -m "post(${TARGET_DATE}): ${TITLE} (Tier ${TIER})" >> "$LOG" 2>&1; then
   log "Committed $SLUG on $DEPLOY_BRANCH ($(git rev-parse --short HEAD))"
 else
   log "commit produced nothing (already committed?) — continuing"


### PR DESCRIPTION
## What
Hard-ban em dashes / en dashes and expand the AI-slop forbidden list for daily morning posts. Add a deterministic voice linter and fail closed at produce and land.

## Why
Recent posts were carrying ~16 em dashes per 1k words (median ~29 per post). That is a clear AI voice fingerprint. The skill only banned a handful of phrases and had no punctuation rule. Gates (consistency / fact / SEO / land) never checked style.

## Decision rationale
- **Prompt + deterministic gate**, not prompt-only (models ignore soft rules).
- **No Vale in this repo today** (CI is shellcheck / ruff / hugo only). A small Python gate matches the produce→land pattern and avoids bulk-failing historical `content/posts/`.
- **No retro rewrite** of published posts; only the post being produced/landed (and PR-changed posts) is linted.

## How it works
1. Writer rules: `write-post.md` + `writer-briefing-template.md` (hard ban dashes + expanded phrase list).
2. Skill step 5: must run `lint-post-voice.py` before `ready:true`.
3. `blog-land.sh` precondition: same lint; fail → quarantine (not publish).
4. CI: `voice-lint` job on PR for changed `content/posts/*.md` only.

## Verification
- Dirty post (`empty-is-not-clean.md`): exit 1, 40 em-dash hits.
- Clean fixture: exit 0.
- Phrase fixture (`Let's dive in`): exit 1.
- `ruff check` on new script: clean.
- `shellcheck -S style scripts/blog/blog-land.sh`: clean.

## Risk
- Tomorrow's backfill will **quarantine** if the writer still emits dashes until it revises clean (desired).
- `comprehensive` / `leverage` bans may false-positive on rare legitimate technical wording; tighten list if that fires.

## Follow-up
- Bead `startaitools-5y1`.
- Optional: add Vale later if you want broader prose rules; not required for this ban.

## Refs
Refs startaitools-5y1