### PR TITLE
docs(ops): point VPS authority to Intent OS

### DIFF
--- a/content/projects.md
+++ b/content/projects.md
@@ -59,7 +59,7 @@ Real-time broadcast operations dashboard for Atlanta Braves radio. Microservices
 
 ### Intent Solutions VPS
 
-A single Contabo VDS hosts five containerized stacks behind one Caddy ingress: Plane (project management), Twenty (CRM), Umami (analytics), ntfy (notifications), and the Braves Booth stack. Watchtower auto-updates the off-the-shelf services; per-repo CI/CD handles the bespoke ones. The migration runbook is open: [intentsolutions-vps-runbook](https://github.com/jeremylongshore/intentsolutions-vps-runbook).
+A single Contabo VDS hosts the self-hosted estate behind one Caddy ingress. Current operational authority, inventory, deployment, backup, and recovery contracts live in private Mission Control (`intent-solutions-io/intent-os`); the former public-facing runbook name is a historical archive notice only.
 
 ### Partner deliverable portal
 

--- a/scripts/blog/lib-cron-common.sh
+++ b/scripts/blog/lib-cron-common.sh
@@ -155,7 +155,7 @@ _log() {
 # Failures-only by design: success and OK-WITH-WARNING stay on email (the brief/
 # digest itself), so #cron-failures carries signal, not routine chatter. ntfy was
 # retired 2026-06-13 — Slack is now the only interrupt channel (VPS + dev box
-# both; see intentsolutions-vps-runbook/docs/alert-routing.md).
+# both; see intent-os/ops/observability/runbooks/alert-routing.md).
 #
 # Never fails the caller: curl/jq errors are swallowed and it always returns 0,
 # so a Slack outage can't flip a cron wrapper's exit status.

--- a/static/_redirects
+++ b/static/_redirects
@@ -11,5 +11,5 @@
 # and CORS never enters the picture. Backend: 127.0.0.1:8090 on intentsolutions VPS,
 # fronted by Caddy at tonsofskills.com/api/forms/*. Forwards {email, source, website}
 # to the Slack webhook from /etc/intentsolutions/notify.env.
-# Runbook: intentsolutions-vps-runbook/docs/tonsofskills-forms-api.md
+# Runbook: intent-os/ops/host/services/forms-api
 /api/forms/*  https://tonsofskills.com/api/forms/:splat  200


### PR DESCRIPTION
Cuts active workflow and operator references over to the D90 Intent OS authority. Historical evidence references are preserved. No runtime, credential, schedule, or deployment behavior changes.