### PR TITLE
ops(web-analytics): deterministic MiniMax pipeline for the daily analytics email

### DIFF
--- a/.claude/skills/blog-backfill/scripts/apply-patterns.py
+++ b/.claude/skills/blog-backfill/scripts/apply-patterns.py
@@ -33,6 +33,7 @@ Exit 0 on success. Never raises on bad data: on any load/parse error it warns to
 stderr and passes the classification through UNCHANGED, because this runs on the
 land path where a crash would quarantine the post.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -70,7 +71,12 @@ def features(dimensions: dict, provisional_tier: int | None) -> dict:
     rpr = int(dimensions.get("rpr", 0))
     allv = [nov, arc, nar, tch, scp, rpr]
     return {
-        "nov": nov, "arc": arc, "nar": nar, "tch": tch, "scp": scp, "rpr": rpr,
+        "nov": nov,
+        "arc": arc,
+        "nar": nar,
+        "tch": tch,
+        "scp": scp,
+        "rpr": rpr,
         "max_all": max(allv),
         "max_nov_tch_nar": max(nov, tch, nar),
         "count_ge3": sum(1 for d in allv if d >= 3),
@@ -95,11 +101,7 @@ def load_patterns(path: Path = PATTERNS_PATH) -> list[dict]:
         return []
 
     active = [p for p in rows if p.get("active") is True]
-    superseded = {
-        p.get("supersedes", "").split(" ")[0]
-        for p in active
-        if p.get("supersedes")
-    }
+    superseded = {p.get("supersedes", "").split(" ")[0] for p in active if p.get("supersedes")}
     out = []
     for p in active:
         if p.get("pattern_id") in superseded:
@@ -135,7 +137,8 @@ def apply_to(classification: dict) -> dict:
     if not isinstance(tier, int):
         result.setdefault("applied_patterns", [])
         return result
-    feats = features(dims, tier)
+    # features are recomputed per iteration against the CURRENT result["tier"] (a cap can lower it),
+    # so there is no single up-front feature vector to hoist.
     for p in load_patterns():
         rule = p["rule"]
         if not rule_matches(rule, features(dims, result["tier"])):
@@ -152,7 +155,7 @@ def apply_to(classification: dict) -> dict:
 
 
 def cmd_apply(args) -> int:
-    raw = (Path(args.file).read_text(encoding="utf-8") if args.file else sys.stdin.read())
+    raw = Path(args.file).read_text(encoding="utf-8") if args.file else sys.stdin.read()
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -169,12 +172,20 @@ def cmd_backfill(args) -> int:
     """Recompute times_applied for every rule-carrying pattern from real decision
     scores, then rewrite patterns.jsonl in place (only times_applied changes)."""
     try:
-        prows = [json.loads(l) for l in PATTERNS_PATH.read_text(encoding="utf-8").splitlines() if l.strip()]
+        prows = [
+            json.loads(line)
+            for line in PATTERNS_PATH.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
     except Exception as e:  # noqa: BLE001
         _warn(f"cannot read patterns.jsonl ({e})")
         return 1
     try:
-        drows = [json.loads(l) for l in DECISIONS_PATH.read_text(encoding="utf-8").splitlines() if l.strip()]
+        drows = [
+            json.loads(line)
+            for line in DECISIONS_PATH.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
     except Exception as e:  # noqa: BLE001
         _warn(f"cannot read decisions.jsonl ({e})")
         return 1
@@ -206,7 +217,9 @@ def cmd_backfill(args) -> int:
 
     for pid, n in counts.items():
         print(f"{pid}: matches {n} of {len(drows)} decisions")
-    print(f"({'would update' if args.dry_run else 'updated'} times_applied on {changed} pattern(s))")
+    print(
+        f"({'would update' if args.dry_run else 'updated'} times_applied on {changed} pattern(s))"
+    )
     return 0
 
 
@@ -221,19 +234,23 @@ def cmd_list(args) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     sub = ap.add_subparsers(dest="cmd", required=True)
 
     a = sub.add_parser("apply", help="apply patterns to a classification JSON (stdin or --file)")
     a.add_argument("--file", help="read classification JSON from this file instead of stdin")
     a.set_defaults(func=cmd_apply)
 
-    b = sub.add_parser("backfill", help="recompute times_applied from decisions.jsonl and rewrite patterns.jsonl")
+    b = sub.add_parser(
+        "backfill", help="recompute times_applied from decisions.jsonl and rewrite patterns.jsonl"
+    )
     b.add_argument("--dry-run", action="store_true", help="report counts without writing")
     b.set_defaults(func=cmd_backfill)
 
-    l = sub.add_parser("list", help="list the patterns that would be applied")
-    l.set_defaults(func=cmd_list)
+    list_p = sub.add_parser("list", help="list the patterns that would be applied")
+    list_p.set_defaults(func=cmd_list)
 
     args = ap.parse_args(argv)
     return args.func(args)

--- a/.claude/skills/blog-backfill/scripts/scan-session-transcripts.py
+++ b/.claude/skills/blog-backfill/scripts/scan-session-transcripts.py
@@ -33,6 +33,7 @@ Usage:
     python3 scan-session-transcripts.py --start 2026-07-15 --json
     python3 scan-session-transcripts.py --start 2026-07-15 --sources claude,grok
 """
+
 from __future__ import annotations
 
 import argparse
@@ -51,10 +52,10 @@ CODEX_DIR = HOME / ".codex" / "sessions"
 CODEX_CONFIG = HOME / ".codex" / "config.toml"
 GROK_MODEL_CACHE = HOME / ".grok" / "models_cache.json"
 
-MAX_ASSISTANT_CHARS = 900      # was 500; keep more substance, still bounded
-MAX_USER_CHARS = 1200          # user turns are the highest-value signal
+MAX_ASSISTANT_CHARS = 900  # was 500; keep more substance, still bounded
+MAX_USER_CHARS = 1200  # user turns are the highest-value signal
 MAX_EXCERPTS_PER_SESSION = 30
-SESSION_GAP_SECONDS = 1800     # >30 min gap = new session
+SESSION_GAP_SECONDS = 1800  # >30 min gap = new session
 
 # ---- Exact model display names (SEO: full names, never the bare vendor) ------
 MODEL_DISPLAY = {
@@ -79,8 +80,15 @@ MODEL_DISPLAY = {
 
 # Brand-correct capitalization for vendor tokens (generic fallback casing).
 _VENDOR_CASE = {
-    "gpt": "GPT", "openai": "OpenAI", "deepseek": "DeepSeek", "minimax": "MiniMax",
-    "gemini": "Gemini", "grok": "Grok", "claude": "Claude", "qwen": "Qwen", "llama": "Llama",
+    "gpt": "GPT",
+    "openai": "OpenAI",
+    "deepseek": "DeepSeek",
+    "minimax": "MiniMax",
+    "gemini": "Gemini",
+    "grok": "Grok",
+    "claude": "Claude",
+    "qwen": "Qwen",
+    "llama": "Llama",
 }
 
 
@@ -94,7 +102,7 @@ def display_model(raw: str | None) -> str | None:
     if not raw or raw == "<synthetic>":
         return None
     raw = raw.strip()
-    if "/" in raw:                       # provider/model form
+    if "/" in raw:  # provider/model form
         raw = raw.split("/")[-1]
     if raw in MODEL_DISPLAY:
         return MODEL_DISPLAY[raw]
@@ -106,7 +114,11 @@ def display_model(raw: str | None) -> str | None:
         vendor = _VENDOR_CASE.get(parts[0].lower(), parts[0].capitalize())
         rest = []
         for p in parts[1:]:
-            rest.append(p.replace(".", "").capitalize() if not any(c.isdigit() for c in p) else p.replace("-", "."))
+            rest.append(
+                p.replace(".", "").capitalize()
+                if not any(c.isdigit() for c in p)
+                else p.replace("-", ".")
+            )
         return f"{vendor} " + " ".join(rest)
     return _VENDOR_CASE.get(base.lower(), base)
 
@@ -123,12 +135,16 @@ _SECRET_PATTERNS = [
     re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]{16,}"),
     re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"),
     # KEY=secretvalue / "token": "secretvalue" style assignments
-    re.compile(r"(?i)\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|API|AUTH)[A-Z0-9_]*)\b(\s*[:=]\s*[\"']?)([A-Za-z0-9._\-/+]{12,})"),
+    re.compile(
+        r"(?i)\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|API|AUTH)[A-Z0-9_]*)\b(\s*[:=]\s*[\"']?)([A-Za-z0-9._\-/+]{12,})"
+    ),
     # Bare high-entropy token: a 24+ char alphanumeric run with mixed case AND a
     # digit (credential-like). Catches raw key values that leak into errors/logs
     # with no KEY= prefix. Spares git SHAs (lowercase hex, no uppercase) and UUIDs
     # (contain dashes), which are safe to show.
-    re.compile(r"\b(?=[A-Za-z0-9]{24,}\b)(?=[A-Za-z0-9]*[a-z])(?=[A-Za-z0-9]*[A-Z])(?=[A-Za-z0-9]*[0-9])[A-Za-z0-9]{24,}\b"),
+    re.compile(
+        r"\b(?=[A-Za-z0-9]{24,}\b)(?=[A-Za-z0-9]*[a-z])(?=[A-Za-z0-9]*[A-Z])(?=[A-Za-z0-9]*[0-9])[A-Za-z0-9]{24,}\b"
+    ),
 ]
 
 
@@ -210,7 +226,9 @@ def describe_tool(name: str, inp: dict) -> str:
     if name in ("Edit", "Write", "NotebookEdit", "Read"):
         return f"{name} {inp.get('file_path', '')}"
     if name in ("Task", "Agent"):
-        return f"dispatch {inp.get('subagent_type', 'agent')}: {str(inp.get('description', ''))[:80]}"
+        return (
+            f"dispatch {inp.get('subagent_type', 'agent')}: {str(inp.get('description', ''))[:80]}"
+        )
     if name in ("Grep", "Glob"):
         return f"{name} {inp.get('pattern', '')}"
     if name == "WebSearch":
@@ -223,9 +241,16 @@ def describe_tool(name: str, inp: dict) -> str:
 # ---- Event model -------------------------------------------------------------
 def _event(ts, source, model, project, role, kind, text="", tool="", is_error=False, note=""):
     return {
-        "ts": ts, "source": source, "model": model, "project": project,
-        "role": role, "kind": kind, "text": text, "tool": tool,
-        "is_error": is_error, "note": note,
+        "ts": ts,
+        "source": source,
+        "model": model,
+        "project": project,
+        "role": role,
+        "kind": kind,
+        "text": text,
+        "tool": tool,
+        "is_error": is_error,
+        "note": note,
     }
 
 
@@ -242,7 +267,7 @@ def _project_from_dir(dirname: str) -> str:
     name = dirname.lstrip("-")
     for prefix in ("home-jeremy-000-projects-", "home-jeremy-"):
         if name.startswith(prefix):
-            name = name[len(prefix):]
+            name = name[len(prefix) :]
             break
     if "--claude-worktrees" in name:
         name = name.split("--claude-worktrees")[0]
@@ -299,14 +324,31 @@ def claude_adapter(start, end):
                         if bt == "text":
                             t = redact((b.get("text") or "").strip())
                             if t:
-                                yield _event(ts, "Claude Code", model, project, role, "text", text=t)
+                                yield _event(
+                                    ts, "Claude Code", model, project, role, "text", text=t
+                                )
                         elif bt == "tool_use" and role == "assistant":
-                            yield _event(ts, "Claude Code", model, project, role, "tool_use",
-                                         tool=describe_tool(b.get("name", ""), b.get("input", {})))
+                            yield _event(
+                                ts,
+                                "Claude Code",
+                                model,
+                                project,
+                                role,
+                                "tool_use",
+                                tool=describe_tool(b.get("name", ""), b.get("input", {})),
+                            )
                         elif bt == "tool_result" and role == "user":
                             err, note = tool_result_error(b)
-                            yield _event(ts, "Claude Code", model, project, role, "tool_result",
-                                         is_error=err, note=note)
+                            yield _event(
+                                ts,
+                                "Claude Code",
+                                model,
+                                project,
+                                role,
+                                "tool_result",
+                                is_error=err,
+                                note=note,
+                            )
             except (OSError, PermissionError):
                 continue
 
@@ -316,6 +358,7 @@ def _grok_model():
     # lists AVAILABLE models, not the active one. Prefer an env override, then a
     # default-flagged cache entry, else the current Grok default.
     import os
+
     if os.environ.get("GROK_MODEL_DISPLAY"):
         return os.environ["GROK_MODEL_DISPLAY"]
     try:
@@ -434,9 +477,9 @@ def _collab_score(m: dict) -> float:
     NARRATIVE) and the debugging drama (failures), so it can separate a genuine
     journey from a merely busy day. Thresholds are set high on purpose: any heavy
     day trips a few transient errors, so 'strong' should require real intensity."""
-    tool = min(m.get("tool_calls", 0) / 150, 1.0)     # ~150 calls = substantial
-    fail = min(m.get("errors_hit", 0) / 12, 1.0)      # ~12 real failures = a rough day
-    corr = min(m.get("corrections", 0) / 5, 1.0)      # ~5 course-corrections = heavy steering
+    tool = min(m.get("tool_calls", 0) / 150, 1.0)  # ~150 calls = substantial
+    fail = min(m.get("errors_hit", 0) / 12, 1.0)  # ~12 real failures = a rough day
+    corr = min(m.get("corrections", 0) / 5, 1.0)  # ~5 course-corrections = heavy steering
     span = min(m.get("span_minutes", 0) / 240, 1.0)
     return round(0.25 * tool + 0.30 * fail + 0.35 * corr + 0.10 * span, 3)
 
@@ -473,11 +516,18 @@ def _rollup_by_date(days: list[dict]) -> dict:
                     models.append(m)
         score = _collab_score(totals)
         sig = _signal(score)
-        hint = (f"{sig}: {totals['errors_hit']} failure-to-fix, {totals['corrections']} "
-                f"course-corrections, {totals['span_minutes']} min"
-                + (f" across {', '.join(models)}" if models else ""))
-        out[date] = {"models": models, "session_signal": sig,
-                     "collaboration_score": score, "totals": totals, "hint": hint}
+        hint = (
+            f"{sig}: {totals['errors_hit']} failure-to-fix, {totals['corrections']} "
+            f"course-corrections, {totals['span_minutes']} min"
+            + (f" across {', '.join(models)}" if models else "")
+        )
+        out[date] = {
+            "models": models,
+            "session_signal": sig,
+            "collaboration_score": score,
+            "totals": totals,
+            "hint": hint,
+        }
     return out
 
 
@@ -522,7 +572,11 @@ def analyze(events):
 
         tool_calls = [e for e in evs if e["kind"] == "tool_use"]
         errors = [e for e in evs if e["kind"] == "tool_result" and e["is_error"]]
-        corrections = [e for e in evs if e["kind"] == "text" and e["role"] == "user" and is_correction(e["text"])]
+        corrections = [
+            e
+            for e in evs
+            if e["kind"] == "text" and e["role"] == "user" and is_correction(e["text"])
+        ]
         tool_breakdown = Counter(e["tool"].split()[0] if e["tool"] else "?" for e in tool_calls)
         span_min = int((evs[-1]["ts"] - evs[0]["ts"]).total_seconds() // 60) if len(evs) > 1 else 0
 
@@ -535,15 +589,25 @@ def analyze(events):
             "tools": dict(tool_breakdown.most_common()),
         }
         score = _collab_score(metrics)
-        out.append({
-            "project": project, "date": date, "sources": sorted({e["source"] for e in evs}),
-            "models": models, "sessions": sessions,
-            "metrics": metrics,
-            "collaboration": {"score": score, "signal": _signal(score)},
-            "failure_arcs": [{"time": e["ts"].strftime("%H:%M"), "note": e["note"]} for e in errors][:12],
-            "corrections_list": [{"time": e["ts"].strftime("%H:%M"), "text": e["text"][:200]} for e in corrections][:12],
-            "excerpts": _excerpts(evs),
-        })
+        out.append(
+            {
+                "project": project,
+                "date": date,
+                "sources": sorted({e["source"] for e in evs}),
+                "models": models,
+                "sessions": sessions,
+                "metrics": metrics,
+                "collaboration": {"score": score, "signal": _signal(score)},
+                "failure_arcs": [
+                    {"time": e["ts"].strftime("%H:%M"), "note": e["note"]} for e in errors
+                ][:12],
+                "corrections_list": [
+                    {"time": e["ts"].strftime("%H:%M"), "text": e["text"][:200]}
+                    for e in corrections
+                ][:12],
+                "excerpts": _excerpts(evs),
+            }
+        )
     return {"models_used": all_models, "date_signals": _rollup_by_date(out), "days": out}
 
 
@@ -555,12 +619,32 @@ def _excerpts(evs):
             t = e["text"]
             if e["role"] == "assistant" and len(t) < 40:
                 continue  # skip short acks; the user turns + tools carry the story
-            ex.append({"time": e["ts"].strftime("%H:%M"), "role": e["role"],
-                       "source": e["source"], "text": t[:cap] + ("..." if len(t) > cap else "")})
+            ex.append(
+                {
+                    "time": e["ts"].strftime("%H:%M"),
+                    "role": e["role"],
+                    "source": e["source"],
+                    "text": t[:cap] + ("..." if len(t) > cap else ""),
+                }
+            )
         elif e["kind"] == "tool_use":
-            ex.append({"time": e["ts"].strftime("%H:%M"), "role": "tool", "source": e["source"], "text": e["tool"]})
+            ex.append(
+                {
+                    "time": e["ts"].strftime("%H:%M"),
+                    "role": "tool",
+                    "source": e["source"],
+                    "text": e["tool"],
+                }
+            )
         elif e["kind"] == "tool_result" and e["is_error"]:
-            ex.append({"time": e["ts"].strftime("%H:%M"), "role": "error", "source": e["source"], "text": e["note"]})
+            ex.append(
+                {
+                    "time": e["ts"].strftime("%H:%M"),
+                    "role": "error",
+                    "source": e["source"],
+                    "text": e["note"],
+                }
+            )
     return ex[: MAX_EXCERPTS_PER_SESSION * 4]
 
 
@@ -581,9 +665,15 @@ def format_text(a) -> str:
         m = d["metrics"]
         L.append(f"=== {d['project']} ({d['date']}) ===")
         L.append(f"Sources: {', '.join(d['sources'])} | Models: {', '.join(d['models']) or 'n/a'}")
-        L.append(f"~{d['sessions']} session(s) | {m['turns']} turns | {m['tool_calls']} tool calls | "
-                 f"{m['corrections']} corrections | {m['errors_hit']} errors hit | {m['span_minutes']} min span")
-        L.append(f"Collaboration signal: {d['collaboration']['signal']} (score {d['collaboration']['score']})")
+        L.append(
+            f"~{d['sessions']} session(s) | {m['turns']} turns | {m['tool_calls']} tool calls | "
+            f"{m['corrections']} corrections | {m['errors_hit']} errors hit | "
+            f"{m['span_minutes']} min span"
+        )
+        L.append(
+            f"Collaboration signal: {d['collaboration']['signal']} "
+            f"(score {d['collaboration']['score']})"
+        )
         if m["tools"]:
             L.append("Tool activity: " + ", ".join(f"{k}×{v}" for k, v in m["tools"].items()))
         if d["failure_arcs"]:
@@ -597,7 +687,9 @@ def format_text(a) -> str:
         L.append("")
         L.append("Transcript (redacted, analyzed excerpts):")
         for e in d["excerpts"]:
-            tag = {"user": "User", "assistant": "AI", "tool": "  ↳", "error": "  ✗"}.get(e["role"], e["role"])
+            tag = {"user": "User", "assistant": "AI", "tool": "  ↳", "error": "  ✗"}.get(
+                e["role"], e["role"]
+            )
             body = e["text"]
             if "\n" in body:
                 first, *rest = body.split("\n")
@@ -614,16 +706,24 @@ def main(argv=None):
     ap.add_argument("--end", default=None, help="End date YYYY-MM-DD (exclusive). Default start+1.")
     ap.add_argument("--output", "-o", default=None, help="Write to file instead of stdout.")
     ap.add_argument("--project", "-p", default=None, help="Filter to a project (substring).")
-    ap.add_argument("--json", action="store_true", help="Emit the structured digest (for pieces 2/3).")
-    ap.add_argument("--sources", default="claude,grok,codex,gemini",
-                    help="Comma list of CLIs to scan (claude,grok,codex,gemini).")
+    ap.add_argument(
+        "--json", action="store_true", help="Emit the structured digest (for pieces 2/3)."
+    )
+    ap.add_argument(
+        "--sources",
+        default="claude,grok,codex,gemini",
+        help="Comma list of CLIs to scan (claude,grok,codex,gemini).",
+    )
     args = ap.parse_args(argv)
 
     start = datetime.strptime(args.start, "%Y-%m-%d")
     end = datetime.strptime(args.end, "%Y-%m-%d") if args.end else start + timedelta(days=1)
     sources = [s.strip().lower() for s in args.sources.split(",") if s.strip()]
 
-    print(f"Scanning {', '.join(sources)} transcripts: {start.date()} to {end.date()}", file=sys.stderr)
+    print(
+        f"Scanning {', '.join(sources)} transcripts: {start.date()} to {end.date()}",
+        file=sys.stderr,
+    )
     events = collect(start, end, sources)
     a = analyze(events)
 
@@ -646,8 +746,11 @@ def main(argv=None):
             pass
         return 0
 
-    print(f"Summary: {len(a['days'])} project-day(s), models: {', '.join(a['models_used']) or 'none'}",
-          file=sys.stderr)
+    print(
+        f"Summary: {len(a['days'])} project-day(s), "
+        f"models: {', '.join(a['models_used']) or 'none'}",
+        file=sys.stderr,
+    )
     return 0
 
 

--- a/scripts/blog/blog-posting-packet.sh
+++ b/scripts/blog/blog-posting-packet.sh
@@ -382,10 +382,14 @@ if [ "${#ENTRIES[@]}" -eq 0 ]; then
     # The liveness beat + daily sweep still cover the "cron stopped firing" case.
     log "No unpacketed posts — nothing to send; sending positive heartbeat email."
     _latest=$(jq -r 'sort_by(.date) | last | "\(.date)  \(.slug)"' "$LEDGER_FILE" 2>/dev/null)
-    node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
+    if node "$EMAIL_SCRIPT" --to jeremy@intentsolutions.io \
       --subject "✓ Blog pipeline healthy — nothing new to syndicate ($(date +%Y-%m-%d))" \
       --body "$(printf 'The blog syndication sweep ran clean and found nothing new to send Ezekiel. This is a normal quiet day, NOT a failure.\n\nWhy no Ezekiel packet: every post in the syndication ledger is already marked packet_sent. A fresh packet goes out the morning after a NEW post lands.\n\nMost recent post in the ledger:\n  %s\n\nIf you expected a new post: the daily backfill produces the PRIOR day post; if that day already had one, it no-ops. See ~/.local/state/blog-backfill-daily/ for todays run.\n' "${_latest:-unknown}")" \
-      >/dev/null 2>&1 && log "heartbeat email sent to jeremy@intentsolutions.io" || log "WARN: heartbeat email failed"
+      >/dev/null 2>&1; then
+      log "heartbeat email sent to jeremy@intentsolutions.io"
+    else
+      log "WARN: heartbeat email failed"
+    fi
   else
     log "No ledger entry for $TARGET_DATE — nothing to build."
   fi

--- a/scripts/blog/next-topics-refresh.sh
+++ b/scripts/blog/next-topics-refresh.sh
@@ -38,7 +38,7 @@ TODAY=$(date +%Y-%m-%d)
 LOG="$LOG_DIR/run-${TODAY}.log"
 BLOG_DIR=/home/jeremy/000-projects/blog/startaitools
 STAGING="$BLOG_DIR/.next-topics.staging.jsonl"
-QUEUE="$BLOG_DIR/.next-topics.jsonl"
+# the live queue (.next-topics.jsonl) is written by next-topics.py, not this wrapper — no bash var needed
 NT_PY="$BLOG_DIR/scripts/blog/next-topics.py"
 EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs
 
@@ -60,6 +60,7 @@ log() { echo "[$(date -Is)] $*" | tee -a "$LOG"; }
 log "=== next-topics refresh start (${TODAY}, agent=${AGENT_NAME}, lookback=${LOOKBACK}d) ==="
 
 NOTIFIED=0
+# shellcheck disable=SC2317  # body reached only via `trap ... EXIT` (shellcheck can't see the dynamic call)
 notify_unexpected_exit() {
   local rc=$?
   liveness_markers "next-topics-refresh" "$rc" 2>/dev/null || true
@@ -108,7 +109,7 @@ if /usr/bin/timeout "$TIMEOUT_SECS" script -e -q -a -c "$AGENT_CMD" "$LOG" >/dev
   WALL=$(( $(date +%s) - T0 )); log "${AGENT_NAME} exited cleanly after ${WALL}s"
 else
   EXIT=$?; WALL=$(( $(date +%s) - T0 ))
-  [ "$EXIT" = "124" ] && log "${AGENT_NAME} TIMED OUT after ${WALL}s" || log "${AGENT_NAME} exited ${EXIT} after ${WALL}s"
+  if [ "$EXIT" = "124" ]; then log "${AGENT_NAME} TIMED OUT after ${WALL}s"; else log "${AGENT_NAME} exited ${EXIT} after ${WALL}s"; fi
   # not fatal on its own — ingest below handles an empty/partial staging file
 fi
 

--- a/scripts/blog/web-analytics-daily.sh
+++ b/scripts/blog/web-analytics-daily.sh
@@ -15,7 +15,7 @@
 # intentsolutions) + recipient are the skill's defaults — see
 # ~/.claude/skills/web-analytics/SKILL.md Step 4 (Email delivery).
 #
-# Agent: WEB_ANALYTICS_AGENT=grok|claude (default: grok). Claude's weekly
+# Agent: WEB_ANALYTICS_AGENT=minimax|grok|claude (default: minimax). Claude's weekly
 # rate-limit killed the 2026-07-15 06:30 run (exit 1 in ~8s). Grok loads the
 # skill via Claude-compat discovery (~/.claude/skills/web-analytics). Data path
 # is Umami REST (curl + UMAMI_PASSWORD from ~/.env), not a required MCP server.
@@ -25,7 +25,7 @@
 # Tunables (env):
 #   WEB_ANALYTICS_TIER      mini | medium | full   (default: medium)
 #   WEB_ANALYTICS_TIMEOUT   hard ceiling seconds    (default: 900)
-#   WEB_ANALYTICS_AGENT     grok | claude           (default: grok)
+#   WEB_ANALYTICS_AGENT     minimax | grok | claude (default: minimax)
 #   WEB_ANALYTICS_MAX_TURNS max agent turns (grok)  (default: 100)
 
 set -uo pipefail
@@ -48,7 +48,7 @@ EMAIL_SCRIPT=/home/jeremy/.claude/skills/email/scripts/send-email.cjs
 SKILL_DIR="${HOME}/.claude/skills/web-analytics"
 TIER="${WEB_ANALYTICS_TIER:-medium}"
 TIMEOUT_SECS="${WEB_ANALYTICS_TIMEOUT:-900}"
-WEB_ANALYTICS_AGENT="${WEB_ANALYTICS_AGENT:-grok}"
+WEB_ANALYTICS_AGENT="${WEB_ANALYTICS_AGENT:-minimax}"
 WEB_ANALYTICS_MAX_TURNS="${WEB_ANALYTICS_MAX_TURNS:-100}"
 GROK_BIN="${GROK_BIN:-$(command -v grok 2>/dev/null || true)}"
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || true)}"
@@ -90,7 +90,7 @@ resolve_agent() {
       fi
       ;;
     *)
-      log "FATAL: unknown WEB_ANALYTICS_AGENT=${WEB_ANALYTICS_AGENT} (want grok|claude)"; return 1
+      log "FATAL: unknown WEB_ANALYTICS_AGENT=${WEB_ANALYTICS_AGENT} (want minimax|grok|claude)"; return 1
       ;;
   esac
   log "FATAL: no agent binary found (grok=$GROK_BIN claude=$CLAUDE_BIN)"; return 1
@@ -98,10 +98,14 @@ resolve_agent() {
 
 log "=== Daily web-analytics email start (tier: ${TIER}, target: ${TODAY}) ==="
 
-if ! resolve_agent; then
-  log "FATAL: cannot resolve agent"; exit 1
+if [ "${WEB_ANALYTICS_AGENT}" = "minimax" ]; then
+  log "agent: minimax deterministic pipeline (Umami fetch -> MiniMax M3 narrative -> render -> send)"
+else
+  if ! resolve_agent; then
+    log "FATAL: cannot resolve agent"; exit 1
+  fi
+  log "agent resolved: name=${AGENT_NAME} bin=${AGENT_BIN} (WEB_ANALYTICS_AGENT=${WEB_ANALYTICS_AGENT})"
 fi
-log "agent resolved: name=${AGENT_NAME} bin=${AGENT_BIN} (WEB_ANALYTICS_AGENT=${WEB_ANALYTICS_AGENT})"
 
 # --- Fail-loud guard: an early/abnormal exit must never be silent ---
 # Mirrors blog-backfill-daily.sh. If the agent or anything before the normal
@@ -124,9 +128,33 @@ notify_unexpected_exit() {
 }
 trap notify_unexpected_exit EXIT
 
-# Run the skill headlessly. script(1) gives the agent a pty so its CLI flushes
-# incrementally instead of buffering until SIGKILL (same rationale as the blog
-# crons — the pty is the precondition for diagnosing a wall-time creep).
+# MiniMax path: a deterministic pipeline owns fetch + render + send. Numbers come from Umami REST,
+# MiniMax M3 writes ONLY the narrative (one API call), the shared renderer owns 100% of the HTML, and
+# send-email.cjs --html delivers. The email can never go out plain or with wrong numbers regardless of
+# the model; if MiniMax is unavailable the pipeline uses a deterministic fallback narrative. The key is
+# read from local SOPS if present (it is a GH Actions secret today — add it to the LLM-keys .env.sops
+# to enable MiniMax narration; until then the correct-numbers fallback runs).
+if [ "${WEB_ANALYTICS_AGENT}" = "minimax" ]; then
+  MINIMAX_SOPS="$HOME/000-projects/intent-eval-platform/intent-eval-lab/.env.sops"
+  if [ -z "${MINIMAX_API_KEY:-}" ] && [ -r "$MINIMAX_SOPS" ] && command -v sops >/dev/null 2>&1; then
+    MINIMAX_API_KEY="$(sops -d --input-type dotenv "$MINIMAX_SOPS" 2>/dev/null | sed -nE 's/^MINIMAX_API_KEY=(.*)$/\1/p' | tr -d "\"'" )"
+    export MINIMAX_API_KEY
+  fi
+  log "Invoking: MiniMax deterministic pipeline (timeout ${TIMEOUT_SECS}s)"
+  T0=$(date +%s)
+  if /usr/bin/timeout "$TIMEOUT_SECS" python3 "$SKILL_DIR/scripts/web-analytics-minimax.py" >>"$LOG" 2>&1; then
+    STATUS="OK"; WALL=$(( $(date +%s) - T0 ))
+    log "MiniMax pipeline delivered the brief after ${WALL}s ($((WALL/60))m $((WALL%60))s)"
+  else
+    EXIT=$?; WALL=$(( $(date +%s) - T0 )); STATUS="FAILED (exit $EXIT)"
+    log "MiniMax pipeline exited non-zero (exit $EXIT) after ${WALL}s"
+  fi
+  PIPELINE_DONE=1
+fi
+
+# Run the skill headlessly (grok/claude agentic path). script(1) gives the agent a pty so its CLI
+# flushes incrementally instead of buffering until SIGKILL (same rationale as the blog crons).
+if [ -z "${PIPELINE_DONE:-}" ]; then
 export CLAUDE_SKILL_DIR="$SKILL_DIR"
 AGENT_CMD=""
 case "$AGENT_NAME" in
@@ -167,6 +195,7 @@ if [ "$STATUS" = "OK" ]; then
     STATUS="OK-WITH-WARNING (no email-send evidence)"
   fi
 fi
+fi  # end grok/claude agentic path (skipped when the MiniMax pipeline ran)
 
 # Consecutive-failure escalation (same pattern as the blog crons).
 CONSEC_FAILS=$(count_consecutive_failures "$LOG_DIR" "run-*.log" "FATAL|TIMED OUT|FAILED \(exit" 10)

--- a/scripts/blog/web-analytics-daily.sh
+++ b/scripts/blog/web-analytics-daily.sh
@@ -137,7 +137,7 @@ trap notify_unexpected_exit EXIT
 if [ "${WEB_ANALYTICS_AGENT}" = "minimax" ]; then
   MINIMAX_SOPS="$HOME/000-projects/intent-eval-platform/intent-eval-lab/.env.sops"
   if [ -z "${MINIMAX_API_KEY:-}" ] && [ -r "$MINIMAX_SOPS" ] && command -v sops >/dev/null 2>&1; then
-    MINIMAX_API_KEY="$(sops -d --input-type dotenv "$MINIMAX_SOPS" 2>/dev/null | sed -nE 's/^MINIMAX_API_KEY=(.*)$/\1/p' | tr -d "\"'" )"
+    MINIMAX_API_KEY="$(sops -d --input-type dotenv --output-type dotenv "$MINIMAX_SOPS" 2>/dev/null | sed -nE 's/^MINIMAX_API_KEY=(.*)$/\1/p' | tr -d "\"'" )"
     export MINIMAX_API_KEY
   fi
   log "Invoking: MiniMax deterministic pipeline (timeout ${TIMEOUT_SECS}s)"


### PR DESCRIPTION
## What

Adds a `WEB_ANALYTICS_AGENT=minimax` path (now the **default**) to the daily web-analytics cron wrapper. In this mode the wrapper runs a deterministic pipeline (`~/.claude/skills/web-analytics/scripts/web-analytics-minimax.py`) instead of an agentic CLI: fetch portfolio metrics from Umami REST -> ask MiniMax M3 for **only** the narrative (one API call) -> render HTML via the shared deterministic template (`render-analytics-email.py`, house style shared with `/contribute`) -> send via `send-email.cjs --html`. The `grok`/`claude` agentic paths are preserved behind the flag.

## Why + decision rationale

The daily analytics email lost its HTML-table formatting when the cron fell back from Claude to Grok (2026-07-15): the old path let the agent free-form the email body. Moving formatting into a deterministic renderer (numbers from Umami, LLM only narrates) makes the email look identical every run regardless of the model, and it can never go out plain or with wrong numbers. **Chose the deterministic-around-the-model design over an agentic MiniMax CLI** because MiniMax M3 is an API model (the way the PR-review lanes use it), not a skill-running harness.

## Layer

Operational cron wrapper (`scripts/blog/web-analytics-daily.sh`). No app/content change. The renderer + pipeline + `SKILL.md` Step 4 live in `~/.claude/skills/web-analytics` (not this repo); this PR is the wrapper wiring only.

## How verified & evidence

- End-to-end wrapper run in minimax mode: `MiniMax pipeline delivered the brief after 14s`, `=== Daily web-analytics email end (OK) ===`.
- Pipeline dry-run against **live Umami** produced real numbers (220 visitors, -11% vs prior day) and rendered HTML.
- A **live sample email** was delivered showing the restored Portfolio-overview / Traffic-sources / Top-content tables in the contribute house style.
- `bash -n` clean.

## Risk assessment

Low. The `grok`/`claude` paths are untouched behind the flag; the pipeline's numbers are deterministic (Umami), so a MiniMax outage degrades to a fallback narrative, not a broken or wrong email. The wrapper's fail-loud alerting still wraps the pipeline.

## Operational impact

- **`MINIMAX_API_KEY` is currently only a GitHub Actions secret** (write-only). Until it is added to the local LLM-keys SOPS (`~/000-projects/intent-eval-platform/intent-eval-lab/.env.sops`), the pipeline runs its **deterministic fallback narrative** (correct numbers + full formatting, just no MiniMax prose). The wrapper reads the key from that SOPS if present.
- No new deps (stdlib Python + existing `send-email.cjs`). Cron schedule unchanged (06:30).

## Follow-up & deferred

- Add `MINIMAX_API_KEY` to local SOPS to enable MiniMax narration (owner action; I cannot read the GH secret).
- Unrelated pre-existing hygiene: `~/.env` line 18 is malformed and echoes a token to stderr when sourced; worth a separate cleanup.

## Refs

Restores the analytics-email HTML formatting; models it on the `/contribute` deterministic recap.

- Jeremy Longshore
intentsolutions.io