### PR TITLE
feat(brand): homepage Intent Solutions contact band + visible mobile contact button

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -281,7 +281,15 @@ header.site-header {
   transition: background-color var(--dur-fast) var(--easing), transform var(--dur-fast) var(--easing), box-shadow var(--dur-fast) var(--easing);
 }
 .nav-cta:hover { background: var(--brand-hover); color: var(--brand-ink); transform: translateY(-1px); box-shadow: 0 0 30px var(--brand-glow); }
-@media (max-width: 680px) { .nav-cta { display: none; } }
+/* Keep the "Work with us" contact button VISIBLE on mobile (was hidden before) — just
+   make it compact. On very small phones drop the search button for room (search still
+   works via Cmd/Ctrl+K and "/"). */
+@media (max-width: 680px) {
+  .nav-cta { padding: var(--sp-2) var(--sp-3); font-size: var(--fs-xs); }
+}
+@media (max-width: 400px) {
+  .search-trigger { display: none; }
+}
 
 .icon-btn {
   display: inline-flex;
@@ -1337,3 +1345,37 @@ body > .content > header:not(.site-header) { display: none !important; }
 .contact-form .form-status.ok { color: var(--brand); }
 .contact-form .form-status.err { color: var(--accent-warm-fg); }
 @media (max-width: 560px) { .contact-form .row { grid-template-columns: 1fr; } .post-cta { padding: var(--sp-6); } }
+
+/* ============================================================
+   Homepage closing CTA band — about Intent Solutions + get in touch.
+   Modeled on intentsolutions.io ContactCta. (added 2026-07-20)
+   ============================================================ */
+.cta-band {
+  position: relative;
+  margin-top: var(--sp-16);
+  padding: var(--sp-24) 0;
+  border-top: 1px solid var(--border);
+  background:
+    radial-gradient(620px 300px at 50% 0%, oklch(72% 0.185 45 / 12%), transparent 62%),
+    var(--bg-inset);
+  overflow: hidden;
+}
+.cta-band-inner { max-width: 46rem; margin: 0 auto; text-align: center; }
+.cta-band-eyebrow {
+  display: flex; align-items: center; justify-content: center; gap: var(--sp-3);
+  margin-bottom: var(--sp-5);
+  font-family: var(--font-display); font-size: var(--fs-xs); font-weight: 700;
+  letter-spacing: 0.24em; text-transform: uppercase; color: var(--brand);
+}
+.cta-band-eyebrow .rule { display: block; height: 1px; width: 3.5rem; background: linear-gradient(to right, transparent, color-mix(in oklch, var(--brand) 45%, transparent)); }
+.cta-band-eyebrow .rule:last-child { background: linear-gradient(to left, transparent, color-mix(in oklch, var(--brand) 45%, transparent)); }
+.cta-band h2 {
+  font-family: var(--font-display);
+  font-size: clamp(var(--fs-2xl), 4vw, var(--fs-4xl));
+  font-weight: 800; line-height: 1.08; letter-spacing: -0.02em;
+  margin: 0 0 var(--sp-4);
+}
+.cta-band h2 .accent { color: var(--brand); }
+.cta-band-sub { font-family: var(--font-sans); font-size: var(--fs-md); color: var(--fg-muted); line-height: var(--lh-relaxed); margin: 0 auto var(--sp-8); max-width: 40rem; }
+.cta-band-actions { display: flex; gap: var(--sp-3); justify-content: center; flex-wrap: wrap; }
+.cta-band-trust { margin-top: var(--sp-5); font-family: var(--font-sans); font-size: var(--fs-sm); color: var(--fg-subtle); }

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -169,4 +169,31 @@
 </section>
 {{- end }}
 
+<!-- ABOUT INTENT SOLUTIONS · GET IN TOUCH -->
+<section class="cta-band" id="get-in-touch">
+  <div class="content">
+    <div class="cta-band-inner" data-reveal>
+      <div class="cta-band-eyebrow" aria-hidden="true">
+        <span class="rule"></span>
+        <span>Start a conversation</span>
+        <span class="rule"></span>
+      </div>
+      <h2>Let's build something that <span class="accent">ships to production</span></h2>
+      <p class="cta-band-sub">
+        Intent Solutions designs, builds, and ships production AI systems: Claude, MCP, RAG,
+        agents, and the boring infrastructure that makes them trustworthy. Tired of AI demos
+        that never make it past the POC?
+      </p>
+      <div class="cta-band-actions">
+        <a href="{{ "/contact/" | relURL }}" class="btn btn-primary">
+          Contact us
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+        </a>
+        <a href="{{ .Site.Params.intentsolutions_url }}" class="btn btn-ghost" rel="noopener">About Intent Solutions</a>
+      </div>
+      <p class="cta-band-trust">No commitment required. We respond within 24 hours.</p>
+    </div>
+  </div>
+</section>
+
 {{ end }}


### PR DESCRIPTION
## What
Follow-up to #33. Two fixes for "no way to get in touch," modeled on intentsolutions.io.

- **Homepage "Get in touch" band** (new closing section, modeled on intentsolutions.io `ContactCta`): "START A CONVERSATION" ember eyebrow, "Let's build something that **ships to production**" (Syne), a subtitle **about Intent Solutions** (the company, not the founder), a primary **Contact us** button → `/contact/`, an **About Intent Solutions** link, and a "We respond within 24 hours" trust line. Lives in the page body, so it shows on **every device**.
- **Mobile fix:** the "Work with us" nav button was `display:none` below 680px — mobile visitors had no visible contact button. It now stays visible (compact); the search button drops only below 400px to free room.

## Why this way
- Put the CTA in the page body rather than relying on the header button, so contact is reachable regardless of viewport/hamburger state.
- Framed copy on Intent Solutions per direction; founder stays out of the homepage pitch.

## Verification
- `hugo --buildFuture --gc --minify`: green.
- Playwright screenshots: mobile header (390px) shows the ember "Work with us" button; the contact band renders with ember eyebrow, Syne title, and both buttons.

Refs startaitools-u66

- Jeremy Longshore
intentsolutions.io