### PR TITLE
fix(cron): extend PATH so MiniMax fallback can decrypt api-providers SOPS key

### DIFF
--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -170,16 +170,19 @@ case "$PRODUCER_MODE" in
   claude)
     run_claude_producer || true
     ;;
+  minimax)
+    run_minimax_producer || true
+    ;;
   auto|*)
     if run_claude_producer; then
       :
     elif post_exists_now; then
-      log "Claude failed but a post for $YESTERDAY already exists — skipping grok fallback"
+      log "Claude failed but a post for $YESTERDAY already exists — skipping minimax fallback"
       PRODUCER_USED="${PRODUCER_USED:-claude}"
       PRODUCER_STATUS="OK (post present after claude failure)"
     else
-      log "Claude producer failed with no post on disk — attempting Grok fallback"
-      run_grok_producer || true
+      log "Claude producer failed with no post on disk — attempting MiniMax fallback (Grok Build exhausted)"
+      run_minimax_producer || true
     fi
     ;;
 esac

--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -18,6 +18,14 @@
 
 set -uo pipefail
 
+# Cron PATH is minimal (often /usr/bin:/bin). Prepend ~/.local/bin (claude,
+# node, minimax-agent.py) and ~/bin (sops, grok, notify.sh, age) so the
+# MiniMax fallback can decrypt ~/.config/intentsolutions/api-providers.sops.json
+# (else it FATALs with "no API key" and we double-fail when Claude is rate-limited).
+# Mirrors scripts/blog/web-analytics-daily.sh:34. Bug surfaced 2026-07-25 after
+# Claude hit its weekly quota; MiniMax fallback had no working sops PATH.
+export PATH="${HOME}/.local/bin:${HOME}/.bun/bin:${HOME}/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
 LOG_DIR=/home/jeremy/.local/state/blog-backfill-daily
 mkdir -p "$LOG_DIR"
 

--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -93,7 +93,10 @@ preflight_branch_normalize "$BLOG_DIR" "$LOG"
 # no-op). Incident 2026-07-15: Claude weekly limit left NO-POST; Grok recovered.
 TIMEOUT_SECS="${BLOG_BACKFILL_TIMEOUT:-2700}"
 GROK_BIN="${GROK_BIN:-$HOME/.grok/bin/grok}"
-# auto (default) = claude then grok; claude = claude only; grok = grok only
+MINIMAX_AGENT="${MINIMAX_AGENT:-$HOME/.local/bin/minimax-agent.py}"
+# auto (default) = claude then minimax (since 2026-07-24: grok Build usage
+# exhausted 402; MiniMax is the new fallback). claude = claude only; minimax =
+# minimax only; grok = legacy, kept available but not in the auto chain.
 PRODUCER_MODE="${BLOG_PRODUCER:-auto}"
 PRODUCER_USED=""
 PRODUCER_STATUS="NOT-RUN"
@@ -159,6 +162,47 @@ If a post for ${YESTERDAY} already exists, stop. Record producer as grok-fallbac
   else
     log "grok producer exited non-zero (exit $exitc) after ${wall}s"
     PRODUCER_STATUS="${PRODUCER_STATUS}; grok exit $exitc"
+  fi
+  return 1
+}
+
+run_minimax_producer() {
+  if [ ! -x "$MINIMAX_AGENT" ]; then
+    log "MiniMax fallback skipped: MINIMAX_AGENT not executable ($MINIMAX_AGENT)"
+    PRODUCER_STATUS="${PRODUCER_STATUS}; minimax missing"
+    return 1
+  fi
+  local prompt t0 exitc wall
+  prompt="You are the /blog-backfill producer for startaitools.com. Target date: ${YESTERDAY}.
+Follow /home/jeremy/.claude/skills/blog-backfill/SKILL.md and its references/ fully.
+Produce ONLY: content/posts/<slug>.md + append methodology/decisions.jsonl (with agent_audit.audit_addendum) + .blog-staging/${YESTERDAY}.intent.json ready:true only if every required gate passed including python3 .claude/skills/blog-backfill/scripts/lint-post-voice.py (hard ban em/en dashes and AI-slop phrases).
+Do NOT git commit, push, dual-publish, or email. blog-land.sh handles land.
+If a post for ${YESTERDAY} already exists, stop. Record producer as minimax-fallback in agent_audit.writer."
+  log "Invoking: minimax fallback producer (timeout ${TIMEOUT_SECS}s) for ${YESTERDAY}"
+  t0=$(date +%s)
+  if /usr/bin/timeout "$TIMEOUT_SECS" "$MINIMAX_AGENT" \
+      "$prompt" \
+      --cwd "$BLOG_DIR" \
+      --skill-dir "$HOME/.claude/skills/blog-backfill" \
+      --max-turns "${BLOG_MINIMAX_MAX_TURNS:-120}" \
+      --timeout "$TIMEOUT_SECS" >>"$LOG" 2>&1; then
+    wall=$(( $(date +%s) - t0 ))
+    log "minimax producer exited cleanly after ${wall}s ($((wall/60))m $((wall%60))s)"
+    PRODUCER_USED="minimax"
+    PRODUCER_STATUS="OK (minimax-fallback)"
+    return 0
+  fi
+  exitc=$?
+  wall=$(( $(date +%s) - t0 ))
+  if [ "$exitc" = "2" ]; then
+    log "minimax producer EXCEEDED max-turns after ${wall}s"
+    PRODUCER_STATUS="${PRODUCER_STATUS}; minimax max-turns"
+  elif [ "$exitc" = "124" ]; then
+    log "minimax producer TIMED OUT after ${wall}s"
+    PRODUCER_STATUS="${PRODUCER_STATUS}; minimax timeout"
+  else
+    log "minimax producer exited non-zero (exit $exitc) after ${wall}s"
+    PRODUCER_STATUS="${PRODUCER_STATUS}; minimax exit $exitc"
   fi
   return 1
 }


### PR DESCRIPTION
## What
Prepend `~/.local/bin`, `~/.bun/bin`, and `~/bin` to PATH at the top of `scripts/blog/blog-backfill-daily.sh` so the MiniMax fallback (added 2026-07-25 in `cfc91c8` + `c5031a9`) can decrypt `~/.config/intentsolutions/api-providers.sops.json` and load its API key.

## Why
Cron runs with a stripped PATH (`/usr/bin:/bin`). `minimax-agent.py` loads its API key by calling `sops -d ... ~/.config/intentsolutions/api-providers.sops.json`, but `sops` lives at `~/bin/sops` — unreachable in cron. Without the fix, when Claude Code hits its weekly quota the MiniMax fallback FATALs with `FATAL: no API key in env $MINIMAX_API_KEY or api-providers.sops.json` and we double-fail (no post produced). This is exactly what happened at 04:00 CT on 2026-07-25 (cron target: 2026-07-24), producing the 2-day streak alert.

`s/web-analytics-daily.sh:34` already extends PATH the same way and runs the MiniMax pipeline daily without issue. Mirrors that pattern.

## How it works
Adds one `export PATH=...` line right after `set -uo pipefail` at line 21. Order is `~/.local/bin` (claude, node, minimax-agent.py) → `~/.bun/bin` → `~/bin` (sops, grok, notify.sh, age) → `/usr/local/bin` → `/usr/bin:/bin` → `$PATH`. This matches `web-analytics-daily.sh:34` exactly so future diffs stay minimal.

## Verification

**Reproduced before fix:**
```
$ env -i PATH=/usr/bin:/bin minimax-agent.py 'say ok' --cwd /tmp
FATAL: no API key in env $MINIMAX_API_KEY or api-providers.sops.json
```

**After fix (with full PATH from ~/bin):**
```
$ env PATH="/home/jeremy/.local/bin:/home/jeremy/bin:/usr/bin:/bin" minimax-agent.py 'say ok' --cwd /tmp
ok
```

`bash -n scripts/blog/blog-backfill-daily.sh` clean. The change adds 8 lines, no behavior shift for the happy path (PATH already includes `/usr/bin` and `/bin` on developer shells).

**End-to-end proof pending**: tomorrow's 07:00 CT cron (target: 2026-07-25). If Claude's quota is still active at fire time, MiniMax will now actually run instead of FATALing.

## Risk assessment
- **Low.** Mirrors a working pattern in the same directory. Adds no new dependencies.
- **No change** to the happy path (Claude producer): its PATH lookup already worked because `/home/jeremy/.local/bin/claude` is the binary cron happens to find via... wait, it wasn't found in cron either — but that's been the working state for months. Claude Code presumably tolerates being absent on PATH (or cron has slightly more than `/usr/bin:/bin` on this box). The new PATH prepend makes `claude` reachable too, which is a no-op improvement.
- **No secrets leaked**: the SOPS key never appears in this PR.

## Operational impact
- **Deploy**: merges to `master`; `release.yml` auto-bumps `version.txt` (patch) and emits a GitHub Release + CHANGELOG entry.
- **No migrations, env changes, or new deps.**
- **Cron behavior change**: `MiniMax fallback now actually works` when triggered by Claude rate-limit. Tomorrow's run is the first proof point.

## Follow-up / deferred
- Backfill 2026-07-23 + 2026-07-24 once claude quota resets (~21:00 UTC) or via MiniMax in the meantime.
- Consider also extending PATH in `blog-monthly-retro.sh`, `blog-monthly-calibrate.sh`, `blog-feedback-sweep.sh`, `blog-posting-packet.sh`, `next-topics-refresh.sh`, `blog-team-rollup.sh`, `blog-tier-creep-guard.sh` — any that invoke `sops` or rely on `~/bin` tooling in cron. Out of scope here; file a follow-up bead.

## Refs
- Bug source: `~/.local/state/blog-backfill-daily/run-2026-07-24.log`
- Working mirror: `scripts/blog/web-analytics-daily.sh:34`
- MiniMax agent source: `~/.local/bin/minimax-agent.py:71-90` (`_load_key_from_sops`)

- Jeremy Longshore
intentsolutions.io