### PR TITLE
feat(content): add Hugging Face link to /about/ Connect block

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1455,3 +1455,26 @@ body > .content > header:not(.site-header) { display: none !important; }
 .cta-band-sub { font-family: var(--font-sans); font-size: var(--fs-md); color: var(--fg-muted); line-height: var(--lh-relaxed); margin: 0 auto var(--sp-8); max-width: 40rem; }
 .cta-band-actions { display: flex; gap: var(--sp-3); justify-content: center; flex-wrap: wrap; }
 .cta-band-trust { margin-top: var(--sp-5); font-family: var(--font-sans); font-size: var(--fs-sm); color: var(--fg-subtle); }
+
+/* ============================================================
+   Hugging Face brand mark — used in about.md Connect block
+   and any outbound link pointing at HF. Renders a small
+   inline icon next to the link text so HF reads as its own
+   platform, not just another URL.
+   ============================================================ */
+.hf-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  white-space: nowrap;
+}
+.hf-link::before {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  background: currentColor;
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 1.5c-3 0-5.6 1.7-6.9 4.2L3.5 4.6c-.5-.4-1.2-.3-1.6.2-.4.5-.3 1.2.2 1.6L4 8.1c-.3.9-.5 1.9-.5 3 0 4.7 3.8 8.5 8.5 8.5s8.5-3.8 8.5-8.5c0-1.1-.2-2.1-.5-3l1.9-1.7c.5-.4.6-1.1.2-1.6-.4-.5-1.1-.6-1.6-.2l-1.6 1.1C17.6 3.2 15 1.5 12 1.5zm-3.6 7.2c.6 0 1.1.5 1.1 1.1s-.5 1.1-1.1 1.1-1.1-.5-1.1-1.1.5-1.1 1.1-1.1zm7.2 0c.6 0 1.1.5 1.1 1.1s-.5 1.1-1.1 1.1-1.1-.5-1.1-1.1.5-1.1 1.1-1.1zM12 6c.6 0 1.1.5 1.1 1.1S12.6 8.2 12 8.2s-1.1-.5-1.1-1.1S11.4 6 12 6zm-3 6.5c.4 0 .7.2.9.5.5.7 1.3 1.2 2.1 1.2s1.6-.5 2.1-1.2c.4-.6 1.2-.7 1.7-.3.6.4.7 1.2.3 1.7-.9 1.3-2.5 2.1-4.1 2.1s-3.2-.8-4.1-2.1c-.4-.6-.2-1.4.3-1.7.2-.2.5-.2.8-.2z'/></svg>") center/contain no-repeat;
+          mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 1.5c-3 0-5.6 1.7-6.9 4.2L3.5 4.6c-.5-.4-1.2-.3-1.6.2-.4.5-.3 1.2.2 1.6L4 8.1c-.3.9-.5 1.9-.5 3 0 4.7 3.8 8.5 8.5 8.5s8.5-3.8 8.5-8.5c0-1.1-.2-2.1-.5-3l1.9-1.7c.5-.4.6-1.1.2-1.6-.4-.5-1.1-.6-1.6-.2l-1.6 1.1C17.6 3.2 15 1.5 12 1.5zm-3.6 7.2c.6 0 1.1.5 1.1 1.1s-.5 1.1-1.1 1.1-1.1-.5-1.1-1.1.5-1.1 1.1-1.1zm7.2 0c.6 0 1.1.5 1.1 1.1s-.5 1.1-1.1 1.1-1.1-.5-1.1-1.1.5-1.1 1.1-1.1zM12 6c.6 0 1.1.5 1.1 1.1S12.6 8.2 12 8.2s-1.1-.5-1.1-1.1S11.4 6 12 6zm-3 6.5c.4 0 .7.2.9.5.5.7 1.3 1.2 2.1 1.2s1.6-.5 2.1-1.2c.4-.6 1.2-.7 1.7-.3.6.4.7 1.2.3 1.7-.9 1.3-2.5 2.1-4.1 2.1s-3.2-.8-4.1-2.1c-.4-.6-.2-1.4.3-1.7.2-.2.5-.2.8-.2z'/></svg>") center/contain no-repeat;
+  flex-shrink: 0;
+}

--- a/content/about.md
+++ b/content/about.md
@@ -51,4 +51,4 @@ This blog ([Start AI Tools](/)) is the daily journal — case studies, deep-dive
 
 ## Connect
 
-[GitHub](https://github.com/jeremylongshore) · [X](https://x.com/asphaltcowb0y) · [LinkedIn](https://linkedin.com/in/jeremylongshore) · [intentsolutions.io](https://intentsolutions.io)
+[GitHub](https://github.com/jeremylongshore) · [X](https://x.com/asphaltcowb0y) · [LinkedIn](https://linkedin.com/in/jeremylongshore) · <span class="hf-link">[Hugging Face · Intent Solutions](https://huggingface.co/intent-solutions-io)</span> · [intentsolutions.io](https://intentsolutions.io)


### PR DESCRIPTION
## What
Adds the Intent Solutions Hugging Face organization link to the `/about/` Connect block alongside GitHub, X, LinkedIn, and intentsolutions.io. Renders with a small Hugging Face brand-mark icon (CSS mask, currentColor) so HF reads as its own platform, not just another URL.

## Why
Intent Solutions hosts an Astro landing-page mirror + a README space wrapper on Hugging Face Spaces (`intent-solutions-io-home.static.hf.space` + `intent-solutions-io-readme.static.hf.space`). Adding a discoverable HF link to the about page makes that presence addressable from the canonical surfaces of the estate (startaitools.com + jeremylongshore.com).

## Where
- `content/about.md` — HF link appended to the Connect paragraph, wrapped in `<span class="hf-link">` so the brand mark sits inline next to the link text.
- `assets/css/custom.css` — new `.hf-link` rule with a mask-image Hugging Face face emoji rendered as a `currentColor` inline icon. No extra HTTP requests; no external font; no JavaScript.

## How it works
The brand mark is a single inline SVG path served via `mask-image` data URL, sized at `1em`, colored by `currentColor` (inherits the surrounding link color). The SVG inside the mask is the Hugging Face "🤗" face shape — recognizable across platforms, monochrome (so it matches the surrounding link color), and scales with `em` units.

The link text "Hugging Face · Intent Solutions" sits inside the `<span class="hf-link">` so the icon and text stay glued together as one clickable unit (the underlying `<a>` handles the click).

## Verification

**Local Hugo build:**
```
$ hugo --buildFuture --gc --minify --cleanDestinationDir
2057 pages, 0 errors
```

**Render check on `public/about/index.html`:**
- `<span class="hf-link">` with `huggingface.co/intent-solutions-io` anchor present in the Connect block.
- Minified `custom.min.<hash>.css` contains the `.hf-link` rule.

**Visual proof pending:** Netlify deploy preview.

## Risk
- **Low.** Pure markup + CSS, no JS, no third-party network calls.
- **No secret leak** — the HF org page is public-facing.
- **Backwards compatible**: zero structural changes to existing sections; the HF link is purely additive in the Connect paragraph.

## Operational impact
- Deploy: merges to `master` → `release.yml` auto-bumps version (patch) + GitHub Release + CHANGELOG entry.
- No migrations, no env changes, no new deps.

## Follow-up
- Companion PR on `jeremylongshore.com` adds HF as a brand-mark social-icon next to LinkedIn / Upwork in the existing `.socials` nav.
- If a second HF-hosted surface ships later (a demo space, a model), generalize the link text and consider promoting HF into the `site-links` row in the profile header.

## Refs
- Intent Solutions on Hugging Face: https://huggingface.co/intent-solutions-io
- Companion PR: `jeremylongshore/jeremylongshore.com#18` (HF social-icon on the personal portfolio)

- Jeremy Longshore
intentsolutions.io