### PR TITLE
fix(blog): stop the Hugo→Astro transform emitting a trailing double newline

### DIFF
--- a/.claude/skills/blog-backfill/scripts/test-transform-hugo-to-astro.sh
+++ b/.claude/skills/blog-backfill/scripts/test-transform-hugo-to-astro.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# test-transform-hugo-to-astro.sh — regression corpus for the Hugo→Astro transform.
+#
+# WHY THIS EXISTS
+# ---------------
+# On 2026-07-26 every post the dual-publish pipeline emitted ended with TWO
+# newlines. The consuming repo (claude-code-plugins) lints blog content with
+# markdownlint, so MD012/no-multiple-blanks failed the `markdownlint` job, which
+# fails the `ci-required` aggregate, which blocks EVERY open PR in that repo.
+# It recurred five times in one day and was hand-patched four times before the
+# root cause was fixed here.
+#
+# Root cause: `body` accumulates as `body+="$line"$'\n'`, so it always ends in a
+# newline; the writer then used `echo "$body"`, appending a second one.
+#
+# These tests pin the emitted-file contract so that regression cannot return
+# silently. Run: bash test-transform-hugo-to-astro.sh
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRANSFORM="$HERE/transform-hugo-to-astro.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+ok()   { printf '  ok   %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf '  FAIL %s\n     expected: %s\n     actual:   %s\n' "$1" "$2" "$3"; fail=$((fail + 1)); }
+
+check() { # name expected actual
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1" "$2" "$3"; fi
+}
+
+trailing_newlines() { python3 -c "
+import sys
+s = open(sys.argv[1], encoding='utf-8').read()
+print(len(s) - len(s.rstrip(chr(10))))" "$1"; }
+
+interior_blanks() { python3 -c "
+import sys
+s = open(sys.argv[1], encoding='utf-8').read().rstrip(chr(10))
+print(sum(1 for l in s.split(chr(10)) if l == ''))" "$1"; }
+
+make_post() { # path body-suffix
+  cat > "$1" <<'FM'
++++
+title = "Test Post"
+date = "2026-07-27"
+description = "A fixture"
+tags = ["testing"]
++++
+
+# Heading
+
+First paragraph.
+
+Second paragraph after an interior blank line.
+FM
+  printf '%s' "$2" >> "$1"
+}
+
+echo "transform-hugo-to-astro regression corpus"
+echo
+
+# 1. The exact defect: source ending with a single newline must emit ONE newline.
+make_post "$TMP/a.md" ''
+bash "$TRANSFORM" "$TMP/a.md" "$TMP/a.out.md" >/dev/null 2>&1
+check "single trailing newline in source -> exactly 1 in output" "1" "$(trailing_newlines "$TMP/a.out.md")"
+
+# 2. Source with trailing blank lines must still emit exactly ONE newline.
+make_post "$TMP/b.md" $'\n\n\n'
+bash "$TRANSFORM" "$TMP/b.md" "$TMP/b.out.md" >/dev/null 2>&1
+check "multiple trailing blank lines collapse to 1 newline" "1" "$(trailing_newlines "$TMP/b.out.md")"
+
+# 3. Interior blank lines are structural markdown and must survive untouched.
+#    The fixture body is: <blank> / "# Heading" / <blank> / "First paragraph." /
+#    <blank> / "Second paragraph...". The LEADING blank is stripped by design
+#    (`sed '/./,$!d'`), leaving the 2 genuinely interior blanks.
+check "interior blank lines preserved (not collapsed)" "2" "$(interior_blanks "$TMP/a.out.md")"
+
+# 4. Frontmatter is still emitted and the body is not truncated.
+check "astro frontmatter opens the file" "---" "$(head -1 "$TMP/a.out.md")"
+check "body content survives" "1" "$(grep -c 'Second paragraph after an interior blank line.' "$TMP/a.out.md")"
+
+# 5. The consuming repo's actual gate: MD012 must not fire.
+if command -v npx >/dev/null 2>&1; then
+  md012=$(cd "$TMP" && timeout 120 npx -y markdownlint-cli2 'a.out.md' 'b.out.md' 2>&1 | grep -c 'MD012' || true)
+  check "markdownlint MD012/no-multiple-blanks does not fire" "0" "$md012"
+else
+  echo "  skip markdownlint check (npx unavailable)"
+fi
+
+echo
+echo "  $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]] || exit 1

--- a/.claude/skills/blog-backfill/scripts/test-transform-hugo-to-astro.sh
+++ b/.claude/skills/blog-backfill/scripts/test-transform-hugo-to-astro.sh
@@ -86,7 +86,10 @@ check "body content survives" "1" "$(grep -c 'Second paragraph after an interior
 
 # 5. The consuming repo's actual gate: MD012 must not fire.
 if command -v npx >/dev/null 2>&1; then
-  md012=$(cd "$TMP" && timeout 120 npx -y markdownlint-cli2 'a.out.md' 'b.out.md' 2>&1 | grep -c 'MD012' || true)
+  # The cd+lint runs in its own subshell so a cd failure cannot fall through to
+  # the `|| true`; that guard exists solely for `grep -c`, which exits 1 when the
+  # count is legitimately 0 — which is the passing case here.
+  md012=$( (cd "$TMP" && timeout 120 npx -y markdownlint-cli2 'a.out.md' 'b.out.md' 2>&1) | grep -c 'MD012' || true)
   check "markdownlint MD012/no-multiple-blanks does not fire" "0" "$md012"
 else
   echo "  skip markdownlint check (npx unavailable)"

--- a/.claude/skills/blog-backfill/scripts/transform-hugo-to-astro.sh
+++ b/.claude/skills/blog-backfill/scripts/transform-hugo-to-astro.sh
@@ -143,8 +143,13 @@ transform_single() {
     echo "tags: $normalized_tags"
     echo "featured: $featured"
     echo "---"
-    # Body: strip leading blank lines, keep the rest
-    echo "$body" | sed '/./,$!d'
+    # Body: strip leading AND trailing blank lines, end with exactly one newline.
+    # `body` accumulates as `body+="$line"$'\n'`, so it ALWAYS ends in a newline;
+    # `echo` then appended a second one, so every emitted post ended `\n\n` and
+    # tripped markdownlint MD012 (no-multiple-blanks) in the consuming repo, turning
+    # its main red on every publish. Command substitution strips ALL trailing
+    # newlines; printf restores exactly one. Interior blank lines are untouched.
+    printf '%s\n' "$(printf '%s' "$body" | sed '/./,$!d')"
   } > "$output"
 
   echo "  Transformed: $(basename "$input") → $(basename "$output")" >&2


### PR DESCRIPTION
Upstream fix for a defect that was being hand-patched downstream. **Five recurrences on 2026-07-26 alone; four hand-fixes in `claude-code-plugins` before anyone looked here.**

## What was happening

Every post the dual-publish pipeline emitted ended with **two** newlines. `claude-code-plugins` lints its blog content, so `MD012/no-multiple-blanks` failed the `markdownlint` job → which feeds the `ci-required` aggregate → which blocked **every open PR in that repo**. One blog publish turned their main red.

## Root cause

`body` accumulates a line at a time:

```bash
body+="$line"$n      # always ends in a newline
...
echo "$body" | sed /./,0d   # echo appends a SECOND one
```

The adjacent comment — *"strip leading blank lines"* — shows the leading side was handled and the trailing side was simply missed.

## Fix

```diff
-    echo "$body" | sed /./,0d
+    printf %sn "$(printf %s "$body" | sed /./,0d)"
```

Command substitution strips **all** trailing newlines; `printf` restores exactly one.

**Chose that over `printf '%s' "$body"`** (which would merely preserve body's own single newline) because the substitution form *also* collapses a source post that ends in several blank lines — same defect class, and MD012 fires on those too. Interior blank lines are structural markdown and are untouched by either form.

## Verification

**New regression corpus** `test-transform-hugo-to-astro.sh` — 6 passed / 0 failed:

```
ok   single trailing newline in source -> exactly 1 in output
ok   multiple trailing blank lines collapse to 1 newline
ok   interior blank lines preserved (not collapsed)
ok   astro frontmatter opens the file
ok   body content survives
ok   markdownlint MD012/no-multiple-blanks does not fire
```

**Mutation-verified** — restoring the old `echo` line turns 3 of the 6 red, including the live markdownlint assertion (MD012: 0 → 5 errors). The corpus demonstrably bites.

**Replayed against the three real posts that broke main:**

| Post | published | regenerated |
|---|---|---|
| `now-lms-2-0-and-the-email-cutover` | 2 trailing newlines | **1** |
| `llm-legible-deterministic-architecture` | 2 | **1** |
| `splitting-privileges-at-the-ci-boundary` | 2 | **1** |

`bash -n` and `shellcheck -S error` both clean.

## Risk

Low. One line in the emit path, plus a new test file that nothing imports. Interior formatting is provably unchanged (test 3). Rollback is a one-line revert.

## Operational impact

None — no env, deps, secrets, or deploy-order change. Existing already-published posts are unaffected; this only changes what future publishes emit. The three posts above were already hand-corrected downstream.

## Follow-up

Nothing outstanding. This removes the need for the recurring `fix(blog): collapse ... markdownlint on main` cleanup commits downstream.