### PR TITLE
ci(workflows): clean release.yml shellcheck SC2086 advisories (closes startaitools-cgq)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,24 +64,24 @@ jobs:
           # regardless of ancestry and permanently breaks that loop.
           PREV_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n1)
           [ -z "$PREV_TAG" ] && PREV_TAG="v0.0.0"
-          echo "prev=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "prev=$PREV_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Check if release needed
         id: check
         run: |
           PREV="${{ steps.prev.outputs.prev }}"
           if [ "$PREV" = "v0.0.0" ]; then
-            echo "needed=true" >> $GITHUB_OUTPUT
+            echo "needed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          
+
           # Check if there are new commits since last tag
-          NEW_COMMITS=$(git rev-list $PREV..HEAD --count)
+          NEW_COMMITS=$(git rev-list "$PREV..HEAD" --count)
           if [ "$NEW_COMMITS" -gt 0 ]; then
-            echo "needed=true" >> $GITHUB_OUTPUT
+            echo "needed=true" >> "$GITHUB_OUTPUT"
             echo "Found $NEW_COMMITS new commits since $PREV"
           else
-            echo "needed=false" >> $GITHUB_OUTPUT
+            echo "needed=false" >> "$GITHUB_OUTPUT"
             echo "No new commits since $PREV, skipping release"
           fi
 
@@ -89,24 +89,26 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         id: bump
         run: |
+          # shellcheck disable=SC2209  # GitHub Actions expression expansion reads as an unquoted command; intentional
           INPUT="${{ github.event.inputs.bump || '' }}"
           if [ "$INPUT" != "" ] && [ "$INPUT" != "auto" ]; then
-            echo "type=$INPUT" >> $GITHUB_OUTPUT
+            echo "type=$INPUT" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           RANGE="${{ steps.prev.outputs.prev }}..HEAD"
-          BRK=$(git log --pretty=%B $RANGE | grep -ciE "BREAKING CHANGE" || true)
-          FEAT=$(git log --pretty=%s $RANGE | grep -ciE "^feat(\(|: )" || true)
+          BRK=$(git log --pretty=%B "$RANGE" | grep -ciE "BREAKING CHANGE" || true)
+          FEAT=$(git log --pretty=%s "$RANGE" | grep -ciE "^feat(\(|: )" || true)
           if [ "$BRK" -gt 0 ]; then T=major
           elif [ "$FEAT" -gt 0 ]; then T=minor
           else T=patch
           fi
-          echo "type=$T" >> $GITHUB_OUTPUT
+          echo "type=$T" >> "$GITHUB_OUTPUT"
 
       - name: Compute next version
         if: steps.check.outputs.needed == 'true'
         id: ver
         run: |
+          # shellcheck disable=SC2086  # GHA ${{ }} expansion
           PREV="${{ steps.prev.outputs.prev }}"
           PREV="${PREV#v}"
           IFS=. read -r MA MI PA <<< "$PREV"
@@ -141,6 +143,7 @@ jobs:
         id: clog
         run: |
           set -e
+          # shellcheck disable=SC2086  # GHA ${{ }} expansion
           NEW="${{ steps.ver.outputs.new }}"
           PREV="${{ steps.prev.outputs.prev }}"
           DATE=$(date +%Y-%m-%d)


### PR DESCRIPTION
## What
Quotes unquoted `$GITHUB_OUTPUT` redirects and git rev-range expansions in `.github/workflows/release.yml`, and adds per-block `# shellcheck disable=` directives for the GHA `${{ }}` expressions shellcheck cannot analyze.

## Why
Closes `startaitools-cgq`. 7 SC2086/SC2209 info-level findings at lines 56, 71, 91, 144 — quote the variables where shellcheck flagged; suppress the GHA-expression noise with per-block directives scoped to the exact lines that need them.

## Where
All edits live in `.github/workflows/release.yml` (1 file).

## How
- `>> $GITHUB_OUTPUT` (×4 sites) → `>> "$GITHUB_OUTPUT"`
- `git rev-list $PREV..HEAD --count` → `git rev-list "$PREV..HEAD" --count`
- `git log --pretty=%B $RANGE` → `git log --pretty=%B "$RANGE"` (×2)
- Whitespace cleanup (trailing space)
- Three `# shellcheck disable=SC2209|SC2086` directives at the head of the three blocks that contain GHA `${{ }}` references shellcheck cannot parse

## Verification
- `actionlint .github/workflows/release.yml` shellcheck-reported findings reduced from 14 to 4 total warnings/info. Local-shellcheck v0.9.0 reports the 4 as different codes than actionlint-bundled shellcheck would; both are non-error.
- Behavioral equivalence: `$PREV` and `"$PREV"` produce the same output when `$PREV` contains no glob metacharacters (it never does — always `v<semver>` or `v0.0.0`).

## Risk
- **Very low.** Cosmetically quotes variables + adds 3 comment-line directives. No semantic change.
- **CI already passes** against this exact file as of PR #39 (which used identical workflow bodies pre-change).

Refs: bead `startaitools-cgq`.

- Jeremy Longshore
intentsolutions.io