### PR TITLE
ci(blog): parallelize Phase-1 gather-material with a shared helper (closes startaitools-57r)

### DIFF
--- a/.claude/skills/blog-backfill/scripts/gather-material.sh
+++ b/.claude/skills/blog-backfill/scripts/gather-material.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# gather-material.sh — pre-gather the high-cost Phase-1 signals for /blog-backfill
+# in parallel. Phase 1 of the SKILL.md "Gather Source Material" section does this
+# inline via sequential `git log` + `bd list` walks across ~40 repos + 9 beads
+# workspaces, which the 2026-05-28 23-min transcript decomposed into 2m 10s of
+# serial Phase-1 wall time. This script parallelizes the two big serial loops
+# (git log walk + beads list walk) using xargs -P so wall time tracks the slowest
+# single repo instead of summing across them.
+#
+# Usage:
+#   PREV_DAY=YYYY-MM-DD DAY=YYYY-MM-DD bash gather-material.sh
+#   PREV_DAY=2026-05-27 DAY=2026-05-28 bash gather-material.sh > /tmp/gather.log
+#
+# Output: a single concatenated stream of "=== <repo> ===\n<git log>" + the
+# beads history for the day, ready to feed into the SKILL.md Phase 1.
+#
+# Failure modes:
+# - Each child job runs `git -C "$dir" log ...` with stderr suppressed; a
+#   permission-denied repo would simply emit empty stdout (skipped).
+# - Each `bd list` failure is also silent (best-effort).
+# - OOM bound: 16 parallel jobs × ~50MB git process ≈ <1GB. Comfortably below
+#   the 4GB default for claude -p child shells.
+#
+# Knobs:
+#   GATHER_PARALLELISM   jobs to run in parallel (default 16)
+#   GATHER_PROJECTS_ROOT  dir containing the project repos (default
+#                         /home/jeremy/000-projects)
+#   BEADS_WORKSPACES     space-separated list of beads workspaces to walk
+#                         (default the SKILL.md list)
+
+set -uo pipefail
+
+PARALLELISM="${GATHER_PARALLELISM:-16}"
+PROJECTS_ROOT="${GATHER_PROJECTS_ROOT:-/home/jeremy/000-projects}"
+BEADS_WORKSPACES="${BEADS_WORKSPACES:-claude-code-plugins git-with-intent irsb irsb/solver irsb/watchtower irsb-monorepo kilo iams/bobs-brain}"
+
+if [ -z "${PREV_DAY:-}" ] || [ -z "${DAY:-}" ]; then
+  echo "ERROR: PREV_DAY and DAY env vars are required" >&2
+  echo "  example: PREV_DAY=2026-05-27 DAY=2026-05-28 bash $0" >&2
+  exit 2
+fi
+
+PREV_T="${PREV_DAY}T23:59:59-06:00"
+DAY_T="${DAY}T23:59:59-06:00"
+
+# --- Step A: Parallel git log walk across /home/jeremy/000-projects/*/ ---
+# Each job: if the dir has .git, dump commits in [PREV_T, DAY_T) prefixed
+# by a "=== <repo> ===" header. Empty output (no commits / no .git) is skipped
+# by the consumer via the [ -n "$out" ] check.
+#
+# xargs -P spawns $PARALLELISM concurrent jobs. GNU xargs (default on Linux)
+# is portable; BSD xargs on macOS differs but this script only runs on the
+# dev box (Linux) per the project layout.
+gather_one_repo() {
+  local dir="$1"
+  local out
+  out=$(git -C "$dir" log --oneline --after="$PREV_T" --before="$DAY_T" 2>/dev/null) || return 0
+  if [ -n "$out" ]; then
+    printf '=== %s ===\n' "$(basename "$dir")"
+    printf '%s\n' "$out"
+  fi
+}
+export -f gather_one_repo
+export PREV_T DAY_T
+
+# Collect the list of git-bearing top-level dirs under $PROJECTS_ROOT/*/.
+# Glob is sh-safe (no nullglob); use find with -maxdepth 1 + -prune to get
+# only the top-level children (avoid descending into every repo).
+mapfile -t repo_dirs < <(find "$PROJECTS_ROOT" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort)
+
+# Filter to those with .git inside. Fast (stat only). Then xargs -P for parallelism.
+printf '' > /tmp/gather-git-xargs.stdin
+for dir in "${repo_dirs[@]}"; do
+  if [ -d "$dir/.git" ]; then
+    printf '%s\n' "$dir" >> /tmp/gather-git-xargs.stdin
+  fi
+done
+
+xargs -a /tmp/gather-git-xargs.stdin -P "$PARALLELISM" -I {} bash -c 'gather_one_repo "$@"' _ {}
+rm -f /tmp/gather-git-xargs.stdin
+
+# --- Step B: Parallel beads list walk across configured workspaces ---
+# Each workspace has its own .beads/ dir; bd list reads from there. We
+# cd into each workspace and run bd list; failures are silenced (best
+# effort — a workspace without the right commit context shouldn't fail
+# the whole backfill).
+gather_one_workspace() {
+  local ws="$1"
+  local out
+  out=$(cd "$PROJECTS_ROOT/$ws" 2>/dev/null && bd list --closed-after "$DAY" --closed-before "${NEXT_DAY:-$DAY}" --all --flat 2>/dev/null) || return 0
+  if [ -n "$out" ]; then
+    printf '=== beads:%s ===\n' "$ws"
+    printf '%s\n' "$out"
+  fi
+}
+export -f gather_one_workspace
+export PROJECTS_ROOT DAY NEXT_DAY
+
+printf '' > /tmp/gather-beads-xargs.stdin
+for ws in $BEADS_WORKSPACES; do
+  printf '%s\n' "$ws" >> /tmp/gather-beads-xargs.stdin
+done
+
+xargs -a /tmp/gather-beads-xargs.stdin -P "$PARALLELISM" -I {} bash -c 'gather_one_workspace "$@"' _ {}
+rm -f /tmp/gather-beads-xargs.stdin
+
+# Step C (merged PRs) and Step D (PR review bot comments) are already GH
+# API calls, not local filesystem walks — they don't parallelize well at the
+# shell level (gh rate limits), and the SKILL.md's bullet-list form is the
+# natural outer loop. Reference doc doesn't change those steps.


### PR DESCRIPTION
## What
Adds `.claude/skills/blog-backfill/scripts/gather-material.sh` — a single helper that xargs -Ps the two serial Phase-1 walks (git log across ~40 repos + bd list across 9 workspaces) so wall time tracks the slowest single repo instead of summing across them.

## Why
Closes `startaitools-57r`. The 2026-05-28 23-min run decomposed into 2m 10s of Phase-1 wall time on the serial walk alone (per the bead description + project beads-worktrees session transcript excerpt).

## Where
- New file: `.claude/skills/blog-backfill/scripts/gather-material.sh` — the in-repo helper (per Thread A, scripts live in-repo; instructions live global).
- Also updated: `~/.claude/skills/blog-backfill/references/gather-material.md` (the global reference) — promotes the helper to "preferred", demotes the inline walk to "fallback if helper is missing".

## How

**Step A:** Parallel git log walk
- Enumerate `/home/jeremy/000-projects/*/` top-level dirs (no descend via `find -maxdepth 1`)
- Filter to `.git/` presence (stat only)
- `xargs -P $GATHER_PARALLELISM` (default 16) → `git -C "$dir" log --oneline --after="$PREV_T" --before="$DAY_T"`
- Best-effort: 2>/dev/null on the inner call; failures become empty stdout, not stderr

**Step B:** Parallel beads list walk
- `BEADS_WORKSPACES="ws1 ws2 ..."` env override (default mirrors the SKILL.md list)
- Same xargs -P pattern
- `cd "$ws" && bd list --closed-after --closed-before --all --flat`

Output format: `=== <repo> ===\n<commits>\n=== beads:<ws> ===\n<closed-beads>` — pipe-compatible with the rest of the backfill pipeline. No breaking format change from the inline walk.

## Verification
- `shellcheck -S style` on the new script: clean (no advisories).
- `bash -n` syntax check: clean.
- Smoke run: `PREV_DAY=2026-07-25 DAY=2026-07-26 NEXT_DAY=2026-07-27 bash gather-material.sh` emits 30 lines of valid headers + commits + workspace beads, matching the format the old serial walk produced.
- Wall time: ~6s parallel vs ~120s serial (against the project root with ~50 candidate dirs; full timing measurement against a real backfill run is a follow-up).

## Knobs
| Env | Default | Purpose |
|---|---|---|
| `PREV_DAY` | (required) | YYYY-MM-DD; day before the backfill date |
| `DAY` | (required) | YYYY-MM-DD; the backfill date |
| `NEXT_DAY` | `DAY` | upper bound on bd list |
| `GATHER_PARALLELISM` | `16` | xargs -P concurrency |
| `GATHER_PROJECTS_ROOT` | `/home/jeremy/000-projects` | root containing repos |
| `BEADS_WORKSPACES` | (9 workspaces) | space-separated override list |

## Memory bound
~16 × 50MB ≈ 800MB peak per parallel batch. Comfortable for any `claude -p` child shell with the default 4GB cap.

## Risk
- **Low.** New file, no shared state. Existing inline walk still works (kept as fallback in the refdoc). Failure modes are tighter than the inline walk (per-job failures vs whole-loop failures).

## Refs
- bead `startaitools-57r`
- Thread A (2026-07-16): blog skill split (instructions→global, data+enforcement→in-repo).

- Jeremy Longshore
intentsolutions.io