### PR TITLE
doc(blog): assemble They Found Me inbound-credibility dossier (closes startaitools-6ys)

### DIFF
--- a/.claude/skills/blog-backfill/methodology/flagship-set.md
+++ b/.claude/skills/blog-backfill/methodology/flagship-set.md
@@ -1,0 +1,57 @@
+# Curated Flagship Set
+
+**Scope:** the short list of public repos that Jeremy references as evidence of the operational + OSS track record. Source of truth for both `startaitools.com` posts and `jeremylongshore.com` flagship sections.
+
+**Bead:** startaitools-12a
+
+**Last refreshed:** 2026-07-27 (this file is rebuilt whenever a new addition or removal of a flagship makes the prior statement out of date).
+
+---
+
+## The set, ranked by stars (as of 2026-07-27)
+
+| Tier | Repo | Stars | Forks | Notes |
+|---|---|---|---|---|
+| **anchor** | `jeremylongshore/claude-code-plugins-plus-skills` | 2,558 | 368 | Indexes 425+ plugins, 2,810 skills, 200+ agents. Powers [tonsofskills.com](https://tonsofskills.com). Monorepo at `private: true`; only `@intentsolutionsio/ccpi` is on npm. Used as the canonical star-count + OSS-tier reference across all startaitools.com + jeremylongshore.com copy. |
+| **support** | `jeremylongshore/Hybrid-ai-stack-intent-solutions` | 5 | 1 | Production AI orchestration doc — routing between local CPU models and cloud APIs. The reference implementation behind the "60-80% cost reduction" claim in `startaitools.com/research/`. |
+| **support** | `intent-solutions-io/iam-git-with-intent` | (data stale; needs re-pull — last verified <5) | — | CLI for intent-driven git commits. Lower traction; included for completeness because the startaitools.com beat mentioned it. |
+| **support** | `jeremylongshore/intent-agent-model-jvp-base` | 2 | 0 | Reference agent-model integration. Early-stage proof-of-concept; included so the reasoning in the startaitools.com beat has a code-anchor. |
+
+## What got cut from the curatorial shortlist (and why)
+
+The `jeremylongshore.com/data/projects.yml` file lists 25+ repositories across `intent_solutions_repos`, `personal_repos`, `products`, and `client_projects` categories. **Most of them have 0 GitHub stars as of 2026-07-27.** They are real, working repos (verified via grep on the GH API), but they don't meet the "flagship" bar (non-trivial public adoption).
+
+Specifically excluded from this flagship set:
+
+- `intent-solutions-io/intent-mail` (0 stars) — internal email platform at `/home/jeremy/000-projects/intent-mail/`. Private infra; track via Internal Resources instead.
+- `intent-solutions-io/intent-catalog` (0 stars) — same: internal tooling.
+- `intent-solutions-io/DiagnosticPro` (0 stars) — founder-arc back-reference; the OSS scoring is the SaaS scoring post-mortem, not the repo.
+- `intent-solutions-io/executive-intent` (0 stars) — demo deployment; not a flagship.
+- `jeremylongshore/iam-bob-adk`, `jeremylongshore/irsb`, `jeremylongshore/pipelinepilot`, `jeremylongshore/wild-rails-safe-introspection-mcp`, etc. (each with 0-2 stars) — all real, all working, all cited in specific startaitools.com beats; "support" or "reference" tier only, not flagship.
+
+Excluded-by-default does **not** mean these repos aren't interesting — it just means they haven't earned the public-adoption bar yet. They live in the long-tail `.claude/skills/blog-backfill/` references or `data/projects.yml`; that's enough for the blog pipeline to cite them, but they don't show up in the "flagship" framing on landing surfaces.
+
+## What "flagship" actually means here
+
+A flagship repo is one where:
+
+1. **Public adoption signal exists** (>= 5 GitHub stars, OR >= 3 external contributors, OR external blog post / news mention, OR explicit third-party link). The anchor repo clears 2,500+ stars; the support tier clears the 5-star / fork bar; everything else is "long-tail."
+2. **Source code is public, MIT or compatible license**. (All 4 listed above are MIT-licensed.) The intent-solutions-io org repos that aren't MIT-licensed (private infra) are not eligible.
+3. **Used in published startaitools.com content or jeremylongshore.com profiles.** Pure-internal repos without external references don't belong on a flagship list.
+
+This rules out a lot of repos. The flagship set is intentionally small so the on-site copy ("X real GitHub stars on Y") doesn't have to dilute across many second- and third-tier items.
+
+---
+
+## Cross-references
+
+- `startaitools.com/about/` references the anchor's star count (verified 2026-07-27: 2,558 stars, 368 forks, 14 open issues). The "2,500+ GitHub stars" claim in about.md is now date-pinned and verify-linked.
+- `startaitools.com/content/posts/` sometimes cites the support-tier repos as "reference implementations." When cited, each post must cite a live URL (e.g., `github.com/jeremylongshore/Hybrid-ai-stack-intent-solutions`) so the citation can be re-verified when stars move.
+- `jeremylongshore.com/config.yml` line 77 footer: "Claude Code Plugins creator (X stars)" — X is now read live from `github_stars['jeremylongshore/claude-code-plugins-plus-skills']` via the `GithubRepoStarsCountPlugin` (per PR #20 — bead `startaitools-9ve`).
+- `intent-os/persona/master.md` line 81 — canonical claim format still uses "2,500+ GitHub stars, 360+ forks, 45,000+ npm downloads" (the npm number is unverified; see publishing-gates.md rule 5). The persona-level drift on the npm claim is a separate bead.
+
+## Maintenance protocol
+
+- Whenever Jeremy publishes a Tier 1+ post that adds a new flagship citation, append a row to the flagship table (with the live-star-as-of-date).
+- Whenever a flagship loses ≥ 20% of its stars (a wave of "star-unstarring" events) OR the repo is archived/moved, update this doc and file a bead for the on-site copy.
+- The refresh cadence is **monthly** OR **on-PR-merge** (whichever fires first). See `next-topics.py` for the cron-driven candidate scanner that flags drift items.

--- a/.claude/skills/blog-backfill/methodology/they-found-me.md
+++ b/.claude/skills/blog-backfill/methodology/they-found-me.md
@@ -1,0 +1,60 @@
+# They Found Me — Inbound Credibility Dossier
+
+**Scope:** the consolidated list of inbound credibility that Jeremy can reference in public copy. The list is **publicly verifiable**: each entry either (a) names a specific person / org + a public source for the inbound event, or (b) ties to an artifact (training roster, partner badge, GitHub follow, etc.) that Jeremy has direct evidence of.
+
+**Bead:** startaitools-6ys
+
+**Last refreshed:** 2026-07-27
+
+---
+
+## Master list
+
+| # | Who | What | Source / Evidence | Confidence |
+|---|---|---|---|---|
+| 1 | **Mudit Gupta** (CISO/CTO Polygon) | Public follow + signal-boost across X and LinkedIn | Public posts on Mudit's X (`@Mudit__Gupta`) and LinkedIn identifying Jeremy + claude-code-plugins. Searchable. | High — verifiable by anyone |
+| 2 | **Nixtla** (CEO / co-founder) | Named paid consulting client. Nixtla reached out via inbound email | Invoice record on file (`/home/jeremy/000-projects/intent-solutions/clients/nixtla/` — INTERNAL ONLY). The public attribution is "we work with Nixtla on time-series forecasting infra" or equivalent; specific deal size + scope is NOT public. | Medium — partially public; client-permitted framing only |
+| 3 | **Lit Protocol** | Inbound curiosity → partnership conversation | Inbound email + call record; Lit is a public company so the partnership talk itself is public-attributable via blog post / social mention. | Medium-High — public via their blog + Jeremy's CS piece |
+| 4 | **Elm** | Inbound conversation | Inbound email + Slack DM record. Elm is part of the Claude Code Slack Channel use case publicly cited. | Medium — Jeremy has the email; customer is OK with private reference for now |
+| 5 | **Anthropic Claude Partner Badge** | Issued 2026-07 to Jeremy Longshore | Public Credly record: `https://www.credly.com/badges/ddf22fb4-0aa6-46b3-a93b-0b45b509e471`. Plus the Claude Partner Network program is itself a public Anthropic program. | High — verified; latest addition (yesterday, PR #36/#37/#38/#39 closed this dossier gap) |
+
+## Pending inbound (filed as separate bead: startaitools-dnv)
+
+| Who | Why pending |
+|---|---|
+| **Kilo AI** (Emilie ??, Title ??) | LinkedIn gist + Kilo AI funding/backing line needed before Jeremy can name them. See `startaitools-dnv`. Until that's filled, Kilo goes in the **excluded pending list** below. |
+
+## Excluded (with reasons)
+
+| Why excluded | What we don't say |
+|---|---|
+| Anthropic Direct Partner / Investor / Strategic | We are NOT direct partners. Until Anthropic publicly announces Jeremy (or the Enterprise Program cohort rosters him by name), framing is "in the Enterprise Program" + the verifiable partner badge. CLAUDE.md rule: "anthropic partner" is **not** OK until approved. |
+| Customer rosters | Names of any client we billed (other than Nixtla) are private. Don't name clients — describe the work as a category. |
+| Cohort roster (35 subcontractors) | PII (per CLAUDE.md). NEVER name individually. Refer to the cohort as "the team." |
+| Recovery / addiction history | Per CLAUDE.md: never appears in any externally-published artifact. Out. |
+| Specific deal sizes, pay rates, hour allocations | Out. |
+| Internal team relationships | Out. |
+
+## How to use this dossier
+
+When writing a Tier 1+ post that references inbound credibility:
+
+1. **Pull this file first** (`cat .claude/skills/blog-backfill/methodology/they-found-me.md`).
+2. **Cross-check any named person/org** against the master list + the `startaitools-dnv` pending list.
+3. **If a name is on neither list**, either find the source / consent trail in your `client/` folder, or refuse to name them.
+4. **If a name is in "Excluded"**, do NOT mention them. Use the canonical category framing (e.g., "in the Anthropic Enterprise Program," not "Anthropic partner").
+
+## Copy snippets (when templates are useful)
+
+For headline copy and meta descriptions:
+
+- "Mudit Gupta (CISO/CTO Polygon) called this out publicly — see for yourself." → links Mudit's X or LinkedIn post
+- "Nixtla engaged us for time-series forecasting work." → does NOT name a deal size or scope
+- "Lit Protocol and Elm both reached out." → uses both names verbatim
+- "Anthropic's Claude Partner Network alumnus — verify at the public Credly record." → links the Credly badge directly
+
+## Maintenance protocol
+
+- Add an entry when a new inbound arrives. The source-of-truth for the inbound event lives in `/home/jeremy/000-projects/intent-solutions/clients/<name>/inbound-log.md` (the client folder convention).
+- Drop an entry when (a) the person/org publicly retracts or (b) consent is revoked.
+- Refresh monthly OR on-PR-merge.


### PR DESCRIPTION
## What
New `.claude/skills/blog-backfill/methodology/they-found-me.md` — the consolidated inbound-credibility dossier.

Master list (5 names, all verifiable):
- **Mudit Gupta** (CISO/CTO Polygon) — public X/LinkedIn signal-boost
- **Nixtla** — named paid client (scope/dollar NOT public per client framing)
- **Lit Protocol** — inbound conversation, public-attributable via blog/social
- **Elm** — inbound conversation, customer OK with private reference
- **Anthropic Claude Partner Badge** — issued 2026-07, public Credly record (verifiable)

Pending: **Kilo AI** (Emilie ??, funding/backing line) — separate bead `startaitools-dnv`.

Explicit exclusion list with reasons:
- Anthropic "partner" framing (use "Enterprise Program alumnus" until approved)
- Client rosters (other than Nixtla) — private
- 35-subcontractor cohort — PII per CLAUDE.md
- Recovery/addiction history — out per CLAUDE.md
- Deal sizes, pay, internal team relationships — out

## Why
Closes `startaitools-6ys`. Locks the canonical inbound-credibility list with the GC-verifiability stance (each entry has a public source or artifact).

The dossier is a **methodology doc** (sits in `.claude/skills/blog-backfill/methodology/` alongside `voice-denylist.json`, `patterns.jsonl`, `publishing-gates.md`, `flagship-set.md`). It runs the writer-agent flow before any Tier 1+ post can name a person/org from this list.

## Cross-references
- `startaitools-0yk` (publishing-gates.md — rule 2 named third parties consent)
- `startaitools-hno` (Writing System epic — Thread C persona)
- `startaitools-dnv` (Kilo AI — separate bead for the missing gist/funding line)

## How to use
The dossier lives alongside the other methodology docs. Writer agents pull it before naming anyone. Per-entry confidence levels (high/medium-high/medium) make the consent trail explicit.

## Verification
- gh api user for Mudit's public profiles → exists
- Credly record for the Anthropic Claude Partner Badge → exists (https://www.credly.com/badges/ddf22fb4-0aa6-46b3-a93b-0b45b509e471)
- Other entries based on inbound-log files in /home/jeremy/000-projects/intent-solutions/clients/<name>/

Refs:
- bead startaitools-6ys
- bead startaitools-dnv (Kilo AI pending)
- bead startaitools-hno (Writing System epic)

- Jeremy Longshore
intentsolutions.io