### PR TITLE
fix(blog): emit a canonical pointing home in the syndicated Astro copy

### DIFF
--- a/.claude/skills/blog-backfill/scripts/test-transform-hugo-to-astro.sh
+++ b/.claude/skills/blog-backfill/scripts/test-transform-hugo-to-astro.sh
@@ -95,6 +95,16 @@ else
   echo "  skip markdownlint check (npx unavailable)"
 fi
 
+# 6. Canonical — the syndicated copy must point at the ORIGINAL on startaitools.
+#    Without it the dual-published copy self-canonicalises and the two properties
+#    compete as duplicate content. Must be the FILENAME slug: deriving from the
+#    title breaks current posts (e.g. "Now-LMS 2.0" -> now-lms-20-... which 404s).
+canon=$(grep '^canonical:' "$TMP/a.out.md" | sed 's/canonical: "//;s/"$//')
+check "canonical is emitted" "1" "$(grep -c '^canonical:' "$TMP/a.out.md")"
+check "canonical uses the filename slug" "https://startaitools.com/posts/a/" "$canon"
+check "canonical sits inside the frontmatter" "1" \
+  "$(awk '/^---$/{c++} c==1 && /^canonical:/{found=1} END{print found+0}' "$TMP/a.out.md")"
+
 echo
 echo "  $pass passed, $fail failed"
 [[ "$fail" -eq 0 ]] || exit 1

--- a/.claude/skills/blog-backfill/scripts/transform-hugo-to-astro.sh
+++ b/.claude/skills/blog-backfill/scripts/transform-hugo-to-astro.sh
@@ -142,6 +142,18 @@ transform_single() {
     echo "date: \"$date\""
     echo "tags: $normalized_tags"
     echo "featured: $featured"
+    # canonical — the syndicated copy must point at the ORIGINAL on
+    # startaitools, or the two properties compete for the same keywords as
+    # duplicate content and Google picks a winner arbitrarily.
+    #
+    # The slug is the FILENAME, matching Hugo's /posts/:slug/ permalink for
+    # every post this pipeline has produced since 2026-02 (verified: all 124
+    # filename-slug posts resolve 200; the 52 title-derived URLs are historical,
+    # from an older convention, and are backfilled explicitly downstream rather
+    # than derived). Deriving from the title instead breaks current posts —
+    # e.g. "Now-LMS 2.0" yields now-lms-20-... which 404s.
+    _canon_slug=$(basename "$input" .md)
+    echo "canonical: \"https://startaitools.com/posts/${_canon_slug}/\""
     echo "---"
     # Body: strip leading AND trailing blank lines, end with exactly one newline.
     # `body` accumulates as `body+="$line"$'\n'`, so it ALWAYS ends in a newline;


### PR DESCRIPTION
startaitools.com is the canonical publisher, but the dual-publish pipeline never said so.

## What was wrong

Posts syndicated to tonsofskills.com carried **no canonical**, so the copy self-canonicalised and the two properties competed for identical content.

`blog-land.sh:135` computes `CANONICAL` — but only uses it for liveness checks, the crosspost queue and the ledger. It never reached the transform, and `transform-hugo-to-astro.sh` had no canonical handling at all.

## Why the filename, not the title

My first attempt derived the slug from the title. **That was wrong and I caught it before shipping** — of six recent posts it produced two dead URLs:

```
"Now-LMS 2.0 and the Email Cutover"
  derived → now-lms-20-and-the-email-cutover     404
  live    → now-lms-2-0-and-the-email-cutover    200
```

A canonical pointing at a 404 is worse than none — search engines drop the page.

So I checked the **live sitemap** instead of guessing. Of 176 syndicated posts that resolve on startaitools: **124 live at their filename slug, 52 at a title-derived one.** Every one of the 52 predates 2026-02; every post since is filename-slugged. This pipeline only produces new posts, so the filename is correct. The 52 historical cases are backfilled explicitly downstream from sitemap-verified URLs rather than derived.

## Verification

```
Regression corpus: 9 passed / 0 failed   (was 6; +3 canonical assertions)
MUTATION-VERIFIED: swapping back to title-derivation turns it red (8/1)

Transform re-run over the 6 most recent real posts,
each emitted canonical fetched live:  6/6 → HTTP 200, 0 dead

bash -n + shellcheck (default strictness): clean
```

## Risk

Low. One added frontmatter line in generated output, plus tests. Downstream consumes it as an optional field, so an older consumer ignores it harmlessly. Rollback is a single revert.

## Operational impact

None — no env, deps, or secrets. Takes effect on the next publish.

## For the record — not a bug

`blog-land.sh`'s own `CANONICAL` is **correct** for every post the pipeline produces today, since those are filename-slugged. It would only mis-address the historical title-slugged posts, and it does not create those.

## Refs

Paired with the downstream CCPI change that adds the `canonical` field to the blog schema, passes it to the layout, and backfills 176 existing posts.