### PR TITLE
fix(blog): rewrite Hugo /posts/ links so syndicated copies have no dead links

### DIFF
--- a/.claude/skills/blog-backfill/scripts/test-transform-hugo-to-astro.sh
+++ b/.claude/skills/blog-backfill/scripts/test-transform-hugo-to-astro.sh
@@ -105,6 +105,52 @@ check "canonical uses the filename slug" "https://startaitools.com/posts/a/" "$c
 check "canonical sits inside the frontmatter" "1" \
   "$(awk '/^---$/{c++} c==1 && /^canonical:/{found=1} END{print found+0}' "$TMP/a.out.md")"
 
+# 7. Hugo /posts/ links must not survive into the syndicated copy.
+#    Hugo serves /posts/<slug>/; the destination serves /blog/<slug>/, so a
+#    verbatim carry-over 404s on the destination's own domain. 121 such links
+#    across 32 posts were dead before this was fixed.
+mklinked() { # path
+  cat > "$1" <<'FM'
++++
+title = "Linked Post"
+date = "2026-07-29"
+description = "Has post links"
+tags = ["testing"]
++++
+
+See [a syndicated one](/posts/sibling-exists/) and
+[one that is not syndicated](/posts/never-syndicated/).
+Bare form: [no slash](/posts/sibling-exists).
+Already correct: [leave me](/blog/sibling-exists/).
+External: [ext](https://example.com/posts/foo/).
+FM
+}
+
+mkdir -p "$TMP/out"
+: > "$TMP/out/sibling-exists.md"          # target IS syndicated
+mklinked "$TMP/linked.md"
+bash "$TRANSFORM" "$TMP/linked.md" "$TMP/out/linked.md" >/dev/null 2>&1
+L="$TMP/out/linked.md"
+
+# grep -c counts LINES; these assertions are about OCCURRENCES, and several
+# land on the same line, so count matches instead.
+occ() { grep -o "$1" "$2" 2>/dev/null | wc -l | tr -d ' '; }
+
+# Three links resolve to the syndicated target: the slashed form, the bare form,
+# and the one that was already correct.
+check "syndicated target rewrites to /blog/<slug>/" "3" "$(occ '](/blog/sibling-exists/)' "$L")"
+check "no /posts/ link survives for a syndicated target" "0" "$(occ '](/posts/sibling-exists' "$L")"
+check "unsyndicated target falls back to the startaitools original" "1" \
+  "$(occ '](https://startaitools.com/posts/never-syndicated/)' "$L")"
+check "no site-relative /posts/ link survives at all" "0" "$(occ '](/posts/' "$L")"
+check "an external URL containing /posts/ is untouched" "1" \
+  "$(occ '](https://example.com/posts/foo/)' "$L")"
+
+# The rewrite runs a command substitution over the body, which strips trailing
+# newlines — so re-pin the newline contract on a post that was actually rewritten.
+check "rewritten post still ends with exactly 1 newline" "1" "$(trailing_newlines "$L")"
+check "rewritten post keeps its canonical" "1" "$(grep -c '^canonical:' "$L")"
+
 echo
 echo "  $pass passed, $fail failed"
 [[ "$fail" -eq 0 ]] || exit 1

--- a/.claude/skills/blog-backfill/scripts/transform-hugo-to-astro.sh
+++ b/.claude/skills/blog-backfill/scripts/transform-hugo-to-astro.sh
@@ -130,6 +130,41 @@ transform_single() {
     normalized_tags="[]"
   fi
 
+  # Rewrite Hugo post links so the syndicated copy contains no dead links.
+  #
+  # Hugo serves posts at /posts/<slug>/ and the source bodies link that way (768
+  # such links across content/posts). The destination serves them at /blog/<slug>/,
+  # so every /posts/ link carried across verbatim 404s on the destination. Because
+  # nothing rewrote them, 121 links in 32 syndicated posts were dead — pointing at
+  # the destination's own domain, on the very pages whose canonical tags tell
+  # Google to treat them as copies of startaitools. A one-time sweep had fixed the
+  # then-existing 82 posts; the pipeline was never fixed, so drift resumed.
+  #
+  # Resolution rule, per target:
+  #   syndicated (a sibling .md exists) -> /blog/<slug>/            (internal, keeps the reader)
+  #   not syndicated                    -> the startaitools original (always resolves)
+  #
+  # The fallback is correct unconditionally, so a bulk backfill that has not yet
+  # written a sibling merely yields a cross-domain link instead of an internal
+  # one — never a broken one. That is why the check is allowed to be racy.
+  local _outdir _slug _target
+  _outdir=$(dirname "$output")
+  for _slug in $(printf '%s' "$body" \
+      | grep -oE '\]\(/posts/[A-Za-z0-9._-]+/?\)' \
+      | sed -E 's#^\]\(/posts/##; s#/?\)$##' | sort -u); do
+    if [[ -f "$_outdir/$_slug.md" ]]; then
+      _target="/blog/$_slug/"
+    else
+      _target="https://startaitools.com/posts/$_slug/"
+    fi
+    # '#' as the delimiter because both pattern and replacement contain '/'.
+    # Slugs are [A-Za-z0-9._-] so they carry no sed metacharacters. Both the
+    # trailing-slash and bare forms are matched.
+    body=$(printf '%s' "$body" | sed \
+      -e "s#](/posts/$_slug/)#]($_target)#g" \
+      -e "s#](/posts/$_slug)#]($_target)#g")
+  done
+
   # Escape double quotes in title and description for YAML output
   local safe_title="${title//\"/\\\"}"
   local safe_desc="${description//\"/\\\"}"


### PR DESCRIPTION
## What

The Hugo→Astro syndication transform now resolves `/posts/<slug>/` links before writing the body, instead of carrying them across verbatim.

## Why

Hugo serves posts at `/posts/<slug>/`; the destination serves them at `/blog/<slug>/`. Carried across unchanged, every such link 404s on the destination.

Measured on the destination corpus: **121 dead links across 32 syndicated posts**, 47 distinct targets. They point at the destination's own domain — on the very pages whose canonical tags (added in #51) tell Google to treat them as copies of startaitools. A syndicated duplicate full of dead internal links undercuts exactly the signal #51 set out to send.

**Why it went unnoticed:** the consuming repo runs lychee on every markdown PR and has been finding these every week, but both invocations are configured `fail: false`, so the job reports success regardless. 500 link errors had accumulated behind a green check.

A one-time sweep previously fixed the then-existing 82 posts — which is why 274 links already use the correct `/blog/` shape. The pipeline was never fixed, so drift resumed: all 32 broken posts were syndicated *after* that sweep. Fixing the corpus without fixing the pipeline is what produced this.

## How it works

| Target | Rewritten to |
| --- | --- |
| sibling `<slug>.md` exists (syndicated) | `/blog/<slug>/` — internal, keeps the reader |
| no sibling | `https://startaitools.com/posts/<slug>/` — always resolves |

**Chose conditional over always-cross-domain.** Rewriting everything to startaitools is also link-correct and simpler, but 38 of the 47 targets *are* syndicated, so it would push readers off the destination for no reason. Preferring the internal link when it resolves keeps them on-site and still sends the 9 unsyndicated targets somewhere real.

The existence check is **deliberately allowed to be racy**: during a bulk backfill a sibling may not be written yet, and the fallback is correct unconditionally — worst case is a cross-domain link instead of an internal one, never a broken one.

Sed uses `#` as the delimiter (pattern and replacement both contain `/`), and slugs are constrained to `[A-Za-z0-9._-]` so they carry no sed metacharacters. Both slashed and bare link forms are matched.

## Verification & evidence

7 new assertions in `test-transform-hugo-to-astro.sh` — **16/16 green**. Mutation-tested to prove they aren't vacuous:

```
scan matches nothing (exact pre-fix state)   -> 4 new assertions FAIL
always-cross-domain (drop internal case)     -> 1 FAILS
restored                                     -> 16/16, byte-identical to pre-mutation
```

Covered: slashed form, bare form, already-correct `/blog/` links left alone, an external URL containing `/posts/` left untouched, plus the trailing-newline and canonical contracts re-pinned on a post that actually went through the rewrite (the rewrite uses command substitution, which strips trailing newlines).

Transparency: my first mutation attempt was ineffective — `$(false; printf ...)` still emits, so the loop still ran and the suite correctly stayed green. The numbers above come from a corrected mutation that genuinely disables the scan.

## Risk

Low, and bounded to newly-syndicated posts. Both branches of the rule produce a resolving URL, so the failure mode is a suboptimal link choice rather than a dead one. External URLs containing `/posts/` are provably untouched (asserted). No frontmatter, newline, or canonical behaviour changes — those contracts are re-asserted on a rewritten post.

## Operational impact

None. No deps, no env, no migration. Pipeline-only change; affects the next syndication run onward.

## Follow-up

- The 121 links already sitting in the destination repo are fixed separately there — this repo cannot reach them.
- The `fail: false` lychee config in the consuming repo is the reason this ran unchecked for weeks; tightening that gate is queued there.

Refs #51 (canonical emission — same automation, same class of defect)

- Jeremy Longshore
intentsolutions.io