### PR TITLE
fix: preserve cross-post canonical URLs

### DIFF
--- a/.claude/skills/blog-backfill/scripts/check-crosspost-queue.sh
+++ b/.claude/skills/blog-backfill/scripts/check-crosspost-queue.sh
@@ -10,11 +10,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BLOG_DIR="/home/jeremy/000-projects/blog/startaitools"
-QUEUE_FILE="${BLOG_DIR}/.crosspost-queue.json"
-ASTRO_SCRIPT="${SCRIPT_DIR}/transform-hugo-to-astro.sh"
-DEVTO_SCRIPT="${SCRIPT_DIR}/post-to-devto.sh"
-HASHNODE_SCRIPT="${SCRIPT_DIR}/post-to-hashnode.sh"
+BLOG_DIR="${BLOG_DIR:-/home/jeremy/000-projects/blog/startaitools}"
+QUEUE_FILE="${CROSSPOST_QUEUE_FILE:-${BLOG_DIR}/.crosspost-queue.json}"
+ASTRO_SCRIPT="${ASTRO_SCRIPT:-${SCRIPT_DIR}/transform-hugo-to-astro.sh}"
+DEVTO_SCRIPT="${DEVTO_SCRIPT:-${SCRIPT_DIR}/post-to-devto.sh}"
+HASHNODE_SCRIPT="${HASHNODE_SCRIPT:-${SCRIPT_DIR}/post-to-hashnode.sh}"
 # Medium API channel retired 2026-07-05 (manual via the posting packet now).
 
 dry_run=false
@@ -46,6 +46,8 @@ fi
 now=$(date -u +%s)
 queue=$(cat "$QUEUE_FILE")
 count=$(echo "$queue" | jq 'length')
+tmp_root=$(mktemp -d)
+trap 'rm -rf "$tmp_root"' EXIT
 
 if [[ "$count" -eq 0 ]]; then
   echo "Cross-post queue is empty." >&2
@@ -58,6 +60,7 @@ processed=0
 for i in $(seq 0 $((count - 1))); do
   entry=$(echo "$queue" | jq ".[$i]")
   slug=$(echo "$entry" | jq -r '.slug')
+  canonical_url=$(echo "$entry" | jq -r '.canonical_url')
 
   echo "" >&2
   echo "=== $slug ===" >&2
@@ -70,7 +73,7 @@ for i in $(seq 0 $((count - 1))); do
   fi
 
   # Transform to Astro format in a temp file for the posting scripts
-  astro_tmp=$(mktemp "/tmp/crosspost-${slug}.XXXXXX.md")
+  astro_tmp="${tmp_root}/${slug}.md"
   if [[ -x "$ASTRO_SCRIPT" ]]; then
     "$ASTRO_SCRIPT" "$hugo_file" "$astro_tmp" 2>/dev/null || cp "$hugo_file" "$astro_tmp"
   else
@@ -87,17 +90,24 @@ for i in $(seq 0 $((count - 1))); do
       echo "  DRY RUN: Would post to Dev.to" >&2
     elif [[ -n "${DEVTO_API_KEY:-}" ]]; then
       echo "  Posting to Dev.to..." >&2
-      if devto_url=$("$DEVTO_SCRIPT" "$astro_tmp" 2>&1); then
+      devto_err="${tmp_root}/${slug}.devto.err"
+      if devto_url=$(CANONICAL_OVERRIDE="$canonical_url" "$DEVTO_SCRIPT" "$astro_tmp" 2>"$devto_err") &&
+        [[ "$devto_url" == https://* ]]; then
+        cat "$devto_err" >&2
+        devto_url=$(printf '%s\n' "$devto_url" | tail -1)
         queue=$(printf '%s\n' "$queue" | jq --arg url "$devto_url" --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-          ".[${i}].devto.status = \"published\" | .[${i}].devto.url = \$url | .[${i}].devto.published_at = \$at")
+          ".[${i}].devto.status = \"published\" | .[${i}].devto.url = \$url | .[${i}].devto.published_at = \$at | del(.[${i}].devto.error, .[${i}].devto.retry_after)")
         echo "  Dev.to: published" >&2
         processed=$((processed + 1))
         printf '%s\n' "$queue" | atomic_json_write "$QUEUE_FILE"
       else
-        echo "  Dev.to: FAILED — $devto_url" >&2
-        devto_error=$(printf '%s\n' "$devto_url" | tail -1)
-        queue=$(printf '%s\n' "$queue" | jq --arg error "$devto_error" \
-          ".[${i}].devto.status = \"failed\" | .[${i}].devto.error = \$error")
+        cat "$devto_err" >&2
+        devto_error=$(tail -1 "$devto_err")
+        [[ -n "$devto_error" ]] || devto_error="posting script returned no valid URL"
+        retry_after=$(date -u -d '+15 minutes' +%Y-%m-%dT%H:%M:%SZ)
+        echo "  Dev.to: retryable failure — $devto_error" >&2
+        queue=$(printf '%s\n' "$queue" | jq --arg error "$devto_error" --arg retry "$retry_after" \
+          ".[${i}].devto.status = \"pending\" | .[${i}].devto.error = \$error | .[${i}].devto.publish_after = \$retry | .[${i}].devto.retry_after = \$retry | .[${i}].devto.attempts = ((.[${i}].devto.attempts // 0) + 1)")
         printf '%s\n' "$queue" | atomic_json_write "$QUEUE_FILE"
       fi
     else
@@ -117,17 +127,24 @@ for i in $(seq 0 $((count - 1))); do
       echo "  DRY RUN: Would post to Hashnode" >&2
     elif [[ -n "${HASHNODE_PAT:-}" ]] && [[ -n "${HASHNODE_PUBLICATION_ID:-}" ]]; then
       echo "  Posting to Hashnode..." >&2
-      if hashnode_url=$("$HASHNODE_SCRIPT" "$astro_tmp" 2>&1); then
+      hashnode_err="${tmp_root}/${slug}.hashnode.err"
+      if hashnode_url=$(CANONICAL_OVERRIDE="$canonical_url" "$HASHNODE_SCRIPT" "$astro_tmp" 2>"$hashnode_err") &&
+        [[ "$hashnode_url" == https://* ]]; then
+        cat "$hashnode_err" >&2
+        hashnode_url=$(printf '%s\n' "$hashnode_url" | tail -1)
         queue=$(printf '%s\n' "$queue" | jq --arg url "$hashnode_url" --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-          ".[${i}].hashnode.status = \"published\" | .[${i}].hashnode.url = \$url | .[${i}].hashnode.published_at = \$at")
+          ".[${i}].hashnode.status = \"published\" | .[${i}].hashnode.url = \$url | .[${i}].hashnode.published_at = \$at | del(.[${i}].hashnode.error, .[${i}].hashnode.retry_after)")
         echo "  Hashnode: published" >&2
         processed=$((processed + 1))
         printf '%s\n' "$queue" | atomic_json_write "$QUEUE_FILE"
       else
-        echo "  Hashnode: FAILED — $hashnode_url" >&2
-        hashnode_error=$(printf '%s\n' "$hashnode_url" | tail -1)
-        queue=$(printf '%s\n' "$queue" | jq --arg error "$hashnode_error" \
-          ".[${i}].hashnode.status = \"failed\" | .[${i}].hashnode.error = \$error")
+        cat "$hashnode_err" >&2
+        hashnode_error=$(tail -1 "$hashnode_err")
+        [[ -n "$hashnode_error" ]] || hashnode_error="posting script returned no valid URL"
+        retry_after=$(date -u -d '+15 minutes' +%Y-%m-%dT%H:%M:%SZ)
+        echo "  Hashnode: retryable failure — $hashnode_error" >&2
+        queue=$(printf '%s\n' "$queue" | jq --arg error "$hashnode_error" --arg retry "$retry_after" \
+          ".[${i}].hashnode.status = \"pending\" | .[${i}].hashnode.error = \$error | .[${i}].hashnode.publish_after = \$retry | .[${i}].hashnode.retry_after = \$retry | .[${i}].hashnode.attempts = ((.[${i}].hashnode.attempts // 0) + 1)")
         printf '%s\n' "$queue" | atomic_json_write "$QUEUE_FILE"
       fi
     else
@@ -144,8 +161,6 @@ for i in $(seq 0 $((count - 1))); do
   # the completed-entry filter below (which checks .medium.status != "pending")
   # still resolves — skipped counts as terminal.
 
-  # Clean up temp file
-  rm -f "$astro_tmp"
 done
 
 completed=$(echo "$queue" | jq '[.[] | select(
@@ -160,5 +175,5 @@ completed=$(echo "$queue" | jq '[.[] | select(
 printf '%s\n' "$queue" | atomic_json_write "$QUEUE_FILE"
 
 echo "" >&2
-echo "Queue processed: $processed published, $completed completed entries removed." >&2
+echo "Queue processed: $processed published, $completed terminal entries retained." >&2
 echo "Pending entries: $(echo "$queue" | jq '[.[] | select(.devto.status == "pending" or .hashnode.status == "pending" or .medium.status == "pending")] | length')" >&2

--- a/.claude/skills/blog-backfill/scripts/post-to-hashnode.sh
+++ b/.claude/skills/blog-backfill/scripts/post-to-hashnode.sh
@@ -106,6 +106,12 @@ if [[ "$http_code" -lt 200 ]] || [[ "$http_code" -ge 300 ]]; then
   exit 1
 fi
 
+if [[ $(echo "$draft_body" | jq '.errors | length // 0') -gt 0 ]]; then
+  echo "  ERROR creating draft: GraphQL returned errors" >&2
+  echo "$draft_body" | jq '.errors' >&2
+  exit 1
+fi
+
 draft_id=$(echo "$draft_body" | jq -r '.data.createDraft.draft.id // empty')
 if [[ -z "$draft_id" ]]; then
   echo "  ERROR: No draft ID in response" >&2
@@ -151,8 +157,14 @@ publish_response=$(curl -s -w "\n%{http_code}" \
 http_code=$(echo "$publish_response" | tail -1)
 publish_body=$(echo "$publish_response" | sed '$d')
 
-if [[ "$http_code" -ge 200 ]] && [[ "$http_code" -lt 300 ]]; then
+if [[ "$http_code" -ge 200 ]] && [[ "$http_code" -lt 300 ]] &&
+  [[ $(echo "$publish_body" | jq '.errors | length // 0') -eq 0 ]]; then
   url=$(echo "$publish_body" | jq -r '.data.publishDraft.post.url // "unknown"')
+  if [[ "$url" != https://* ]]; then
+    echo "  ERROR publishing: response did not contain a valid URL" >&2
+    echo "$publish_body" | jq . >&2
+    exit 1
+  fi
   echo "  Published: $url" >&2
   echo "$url"
 else

--- a/scripts/blog/test-pipeline-invariants.sh
+++ b/scripts/blog/test-pipeline-invariants.sh
@@ -36,3 +36,56 @@ if published_post_for_date "$TEST_REPO" "$TEST_REPO/content/posts" 2026-07-29 >/
 fi
 
 echo "pipeline invariant tests: pass"
+
+# Cross-posting must preserve the queue's canonical URL regardless of the
+# transformed file's temporary location, record only the URL from stdout, and
+# leave transient failures pending for a later retry.
+BLOG_FIXTURE="$TEST_REPO/blog"
+STUBS="$TEST_REPO/stubs"
+mkdir -p "$BLOG_FIXTURE/content/posts" "$BLOG_FIXTURE/scripts/blog" "$STUBS"
+cp "$HERE/lib-cron-common.sh" "$BLOG_FIXTURE/scripts/blog/lib-cron-common.sh"
+printf '%s\n' '---' 'title: "Canonical Fixture"' '---' 'Body' \
+  > "$BLOG_FIXTURE/content/posts/canonical-fixture.md"
+
+cat > "$STUBS/transform" <<'EOF'
+#!/usr/bin/env bash
+cp "$1" "$2"
+EOF
+cat > "$STUBS/success" <<'EOF'
+#!/usr/bin/env bash
+[[ $(basename "$1") == "canonical-fixture.md" ]]
+[[ "$CANONICAL_OVERRIDE" == "https://startaitools.com/posts/canonical-fixture/" ]]
+echo "diagnostic output" >&2
+echo "https://external.example/canonical-fixture"
+EOF
+cat > "$STUBS/fail" <<'EOF'
+#!/usr/bin/env bash
+echo "HTTP 429: retry later" >&2
+exit 1
+EOF
+chmod +x "$STUBS/transform" "$STUBS/success" "$STUBS/fail"
+
+jq -n '[{
+  slug: "canonical-fixture",
+  canonical_url: "https://startaitools.com/posts/canonical-fixture/",
+  devto: {status: "pending", publish_after: "1970-01-01T00:00:00Z"},
+  hashnode: {status: "published"},
+  medium: {status: "skipped"}
+}]' > "$BLOG_FIXTURE/.crosspost-queue.json"
+
+PROCESSOR="$HERE/../../.claude/skills/blog-backfill/scripts/check-crosspost-queue.sh"
+BLOG_DIR="$BLOG_FIXTURE" ASTRO_SCRIPT="$STUBS/transform" DEVTO_SCRIPT="$STUBS/success" \
+  DEVTO_API_KEY=test "$PROCESSOR" >/dev/null
+jq -e '.[0].devto.status == "published" and
+  .[0].devto.url == "https://external.example/canonical-fixture"' \
+  "$BLOG_FIXTURE/.crosspost-queue.json" >/dev/null
+
+jq '.[0].devto = {status: "pending", publish_after: "1970-01-01T00:00:00Z"}' \
+  "$BLOG_FIXTURE/.crosspost-queue.json" > "$BLOG_FIXTURE/.crosspost-queue.next"
+mv "$BLOG_FIXTURE/.crosspost-queue.next" "$BLOG_FIXTURE/.crosspost-queue.json"
+BLOG_DIR="$BLOG_FIXTURE" ASTRO_SCRIPT="$STUBS/transform" DEVTO_SCRIPT="$STUBS/fail" \
+  DEVTO_API_KEY=test "$PROCESSOR" >/dev/null
+jq -e '.[0].devto.status == "pending" and .[0].devto.attempts == 1 and
+  (.[0].devto.retry_after | type == "string")' "$BLOG_FIXTURE/.crosspost-queue.json" >/dev/null
+
+echo "cross-post invariant tests: pass"


### PR DESCRIPTION
## Summary
- preserve queue canonical URLs through transformed temp files
- store clean platform URLs while retaining diagnostics in logs
- keep transient API failures pending with a retry timestamp
- reject HTTP-200 Hashnode GraphQL errors and invalid publish URLs
- add regression coverage for canonical propagation and retry state

## Validation
- `shellcheck .claude/skills/blog-backfill/scripts/check-crosspost-queue.sh .claude/skills/blog-backfill/scripts/post-to-hashnode.sh scripts/blog/test-pipeline-invariants.sh`
- `scripts/blog/test-pipeline-invariants.sh`
- `git diff --check`