### PR TITLE
fix(blog-land): split exit 11 into real orphaned-commit vs blocked-before-commit outcomes

### DIFF
--- a/scripts/blog/blog-backfill-daily.sh
+++ b/scripts/blog/blog-backfill-daily.sh
@@ -301,7 +301,8 @@ case "$LAND_RC" in
   0)  STATUS="OK" ;;
   3)  STATUS="OK-WITH-WARNING (pushed, not live yet)" ;;
   10) STATUS="FAILED (QUARANTINED — preconditions failed, tree cleaned)" ;;
-  11) STATUS="FAILED (land infra — see log)" ;;
+  11) STATUS="FAILED (land infra — orphaned local commit, manual push needed)" ;;
+  12) STATUS="FAILED (land BLOCKED before commit — nothing orphaned; re-run land from a normal shell)" ;;
   20) case "$PRODUCER_STATUS" in
         OK*) STATUS="OK (no post — no activity)" ;;
         *)   STATUS="FAILED (${PRODUCER_STATUS}, no post produced)" ;;

--- a/scripts/blog/blog-land.sh
+++ b/scripts/blog/blog-land.sh
@@ -28,7 +28,12 @@
 #   0   OK            — landed and verified live
 #   3   OK-WARNING    — landed + pushed, but not live yet (Netlify lag / probe)
 #   10  QUARANTINED   — a precondition failed; artifacts quarantined, tree clean
-#   11  FAILED        — infra failure (push rejected / orphaned)
+#   11  FAILED        — infra failure with a REAL stranded local commit (push
+#                       rejected while ahead of origin — manual push recovers it)
+#   12  BLOCKED       — commit/push was refused and NO local commit exists
+#                       (nothing orphaned, nothing to push; classic cause: the
+#                       producer git guard active in this environment — the
+#                       2026-08-03 mislabeled "orphaned local commit" incident)
 #   20  NO-POST       — no post exists for the date; nothing to do
 #   21  ALREADY-LANDED— post already committed; queue reprocessed, no new commit
 
@@ -253,11 +258,20 @@ if [ "$DRY_RUN" -eq 1 ]; then
 fi
 
 # ---- Land: commit + push (canonical) ---------------------------------------
-git add "$POST_REL" ".claude/skills/blog-backfill/methodology/decisions.jsonl"
+git add "$POST_REL" ".claude/skills/blog-backfill/methodology/decisions.jsonl" >> "$LOG" 2>&1 || true
 if git commit --no-verify -m "post(${TARGET_DATE}): ${TITLE} (Tier ${TIER})" >> "$LOG" 2>&1; then
   log "Committed $SLUG on $DEPLOY_BRANCH ($(git rev-parse --short HEAD))"
+elif [ -z "$(git status --porcelain -- "$POST_REL" 2>/dev/null)" ]; then
+  log "commit produced nothing (post already committed) — continuing"
 else
-  log "commit produced nothing (already committed?) — continuing"
+  # Commit refused AND the post is still uncommitted: nothing exists to push, so
+  # this is NOT an orphaned commit. The classic cause is the producer git guard
+  # leaking into this environment (2026-08-03: guard rejected commit/push/pull
+  # and the run mislabeled itself "orphaned local commit").
+  log "FATAL: commit refused and '$POST_REL' remains uncommitted — nothing to push (is the producer git guard active in this environment?)"
+  urgent_alert "🚨 blog-land: commit BLOCKED ${TARGET_DATE}" "git commit for '${SLUG}' was refused and the post remains uncommitted. No push was attempted; nothing is orphaned. Likely cause: blog-land invoked inside the producer-guarded environment. Re-run blog-land.sh ${TARGET_DATE} from a normal shell."
+  log "LAND-RESULT: BLOCKED (commit refused — nothing committed, nothing to push)"
+  exit 12
 fi
 if git push origin "$DEPLOY_BRANCH" >> "$LOG" 2>&1; then
   log "Pushed to origin/$DEPLOY_BRANCH"
@@ -266,8 +280,17 @@ else
   if git pull --rebase origin "$DEPLOY_BRANCH" >> "$LOG" 2>&1 && git push origin "$DEPLOY_BRANCH" >> "$LOG" 2>&1; then
     log "Re-push succeeded after rebase"
   else
-    log "FATAL: could not push $SLUG to origin/$DEPLOY_BRANCH"
-    urgent_alert "🚨 blog-land: push FAILED ${TARGET_DATE}" "Committed '${SLUG}' locally but could NOT push to origin/${DEPLOY_BRANCH}. Post is committed but NOT live. Manual push needed."
+    # Distinguish a real stranded commit from a push refused with nothing to
+    # push: only the former is an "orphaned local commit" needing manual push.
+    AHEAD=$(git rev-list --count "origin/${DEPLOY_BRANCH}..HEAD" 2>/dev/null || echo "unknown")
+    if [ "$AHEAD" = "0" ]; then
+      log "FATAL: push refused but HEAD is not ahead of origin/${DEPLOY_BRANCH} — no local commit is stranded (is the producer git guard active in this environment?)"
+      urgent_alert "🚨 blog-land: push BLOCKED ${TARGET_DATE}" "Push for '${SLUG}' was refused but no local commit exists ahead of origin/${DEPLOY_BRANCH} — nothing is orphaned. Likely cause: blog-land invoked inside the producer-guarded environment. Re-run blog-land.sh ${TARGET_DATE} from a normal shell."
+      log "LAND-RESULT: BLOCKED (push refused — nothing committed, nothing to push)"
+      exit 12
+    fi
+    log "FATAL: could not push $SLUG to origin/$DEPLOY_BRANCH (${AHEAD} local commit(s) stranded)"
+    urgent_alert "🚨 blog-land: push FAILED ${TARGET_DATE}" "Committed '${SLUG}' locally but could NOT push to origin/${DEPLOY_BRANCH} (${AHEAD} commit(s) ahead). Post is committed but NOT live. Manual push needed."
     log "LAND-RESULT: FAILED (orphaned local commit)"
     exit 11
   fi


### PR DESCRIPTION
## What

Splits `blog-land.sh`'s exit 11 ("FAILED — orphaned local commit") into two truthful outcomes: exit 11 stays reserved for a **real** stranded local commit (push refused while `git rev-list --count origin/<branch>..HEAD` > 0; alert now includes the ahead-count), and a new exit 12 **BLOCKED** covers commit-or-push refused with **no** commit ahead of origin (nothing orphaned, nothing to push). `blog-backfill-daily.sh` maps exit 12 to a distinct STATUS that names the recovery ("re-run land from a normal shell").

## Why + decision rationale

On the 2026-08-03 recovery, blog-land ran inside an environment where the producer git guard was active: commit, push, and pull were all rejected (`producer git guard: mutation rejected`), no commit ever existed — yet the run alerted "orphaned local commit," pointing the operator at a stranded commit that was never created (incident epic intent-solutions-io/intent-os#360, bead spine-7mq.5). Chose ahead-count classification over sniffing the guard's stderr because it asserts the actual condition (is anything stranded?) and stays correct for any future refusal mechanism. The wrapper's own guard hygiene was audited and is correct (`env PATH=…` scopes the shim to the producer invocation only) — this is defense-in-depth in the lander itself.

## Layer(s) touched

Deterministic land step + daily wrapper STATUS mapping only. No change to preconditions, quarantine, dual-publish, queueing, liveness markers, or the 0/3/10/20/21 codes. Scripts here are canonical AND deployed (cron runs the repo path), so merge == deploy; no copy step.

## How it works

Commit refused + post still uncommitted → exit 12 with "commit refused — nothing committed, nothing to push". Push (and rebase-retry) refused → classify by ahead-count: 0 → exit 12 "push refused — nothing committed"; >0 → exit 11 "orphaned local commit (N stranded)". Both BLOCKED alerts name the likely guarded-environment cause and the recovery command.

## Verification & evidence

- `bash -n` on both scripts.
- Sandbox harness (throwaway bare origin + clone) runs the **verbatim sed-extracted land block** under three scenarios: guard-active commit → rc=12 BLOCKED; pre-receive-refused push with a real commit → rc=11 "orphaned local commit … 1 local commit(s) stranded"; guard-active push with ahead=0 (the 08-03 incident shape) → rc=12 BLOCKED. All three emit the intended distinct `LAND-RESULT` lines.
- Happy-path regression: `blog-land.sh 2099-01-01 --dry-run` from master → rc=20 NO-POST unchanged; wrong-branch refusal path exercised and unchanged (exit 11 pre-commit, by design).

## Risk assessment

Low. New code paths only replace the terminal failure labels; any consumer switching on rc gets 12 only where it previously got a mislabeled 11. The wrapper is the sole rc consumer (verified by grep) and is updated in the same PR.

## Operational impact

None beyond merge (deployed == repo). No env, deps, or secrets.

## Follow-up & deferred

Audit note (tracked in the incident AAR, not fixed here): the wrong-branch refusal fires `urgent_alert` even under `--dry-run`.

## Refs

Refs intent-solutions-io/intent-os#360 (bead spine-7mq.5)
