### PR TITLE
fix(syndication): close the packet-reply loop and alarm when it goes quiet

### DIFF
--- a/scripts/blog/blog-syndication-ingest.sh
+++ b/scripts/blog/blog-syndication-ingest.sh
@@ -35,8 +35,10 @@ log "=== syndication ingest start ==="
 
 # Governed Buzz dispatch (cron_fail / liveness markers); no-op if unavailable.
 INTENT_RUNTIME="${INTENT_RUNTIME:-$HOME/bin/lib/intent-runtime.sh}"
-# shellcheck disable=SC1090
-[ -r "$INTENT_RUNTIME" ] && . "$INTENT_RUNTIME" 2>/dev/null || true
+if [ -r "$INTENT_RUNTIME" ]; then
+  # shellcheck disable=SC1090
+  . "$INTENT_RUNTIME" 2>/dev/null || true
+fi
 
 alert() {
   local msg="$1"

--- a/scripts/blog/blog-syndication-ingest.sh
+++ b/scripts/blog/blog-syndication-ingest.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Close the syndication feedback loop, and alarm when it goes quiet.
+#
+# Runs ingest-syndication-replies.py in two passes:
+#   ingest  parse the poster's packet replies -> record real URLs in the ledger
+#   check   dead-man: packeted posts with nothing recorded after N hours
+#
+# WHY THIS EXISTS: the poster's SOP says "reply to the packet with the URLs",
+# but nothing read those replies, so every ledger destination stayed "pending"
+# forever and the Monday rollup reported zero syndication as though no work had
+# happened. On 2026-08-05 that silent gap was 29 posts deep, back to 2026-07-05.
+# An open loop with no alarm is indistinguishable from a loop nobody is running.
+#
+# Fail-loud, read-only on the mailbox, and safe to run by hand at any time.
+
+set -uo pipefail
+
+BLOG_DIR="${BLOG_DIR:-$HOME/000-projects/blog/startaitools}"
+LOG_DIR="$HOME/.local/state/blog-syndication-ingest"
+LOG="$LOG_DIR/ingest-$(date +%F).log"
+INGEST="$BLOG_DIR/scripts/blog/ingest-syndication-replies.py"
+STALE_HOURS="${STALE_HOURS:-48}"
+
+mkdir -p "$LOG_DIR"
+
+# PATH first, log open before any precondition: a script that dies before its
+# log exists is indistinguishable from one that never ran. (Learned 2026-08-05,
+# the backup-fabric incident: one script lacked this and failed silently for
+# eight nights.)
+export PATH="/usr/local/bin:/usr/bin:/bin:$HOME/bin:$PATH"
+
+log() { echo "[$(date -Is)] $*" | tee -a "$LOG"; }
+
+log "=== syndication ingest start ==="
+
+# Governed Buzz dispatch (cron_fail / liveness markers); no-op if unavailable.
+INTENT_RUNTIME="${INTENT_RUNTIME:-$HOME/bin/lib/intent-runtime.sh}"
+# shellcheck disable=SC1090
+[ -r "$INTENT_RUNTIME" ] && . "$INTENT_RUNTIME" 2>/dev/null || true
+
+alert() {
+  local msg="$1"
+  if command -v cron_fail >/dev/null 2>&1; then
+    cron_fail "blog-syndication-ingest" "$msg"
+  fi
+}
+
+if [ ! -f "$INGEST" ]; then
+  log "FATAL: $INGEST missing"
+  alert "ingester script missing at $INGEST"
+  exit 1
+fi
+
+# --- Pass 1: ingest replies -------------------------------------------------
+if python3 "$INGEST" ingest --days "${INGEST_DAYS:-14}" >> "$LOG" 2>&1; then
+  log "ingest OK"
+else
+  rc=$?
+  log "ingest FAILED (rc=$rc)"
+  alert "reply ingest failed rc=$rc; see $LOG"
+fi
+
+# --- Pass 2: dead-man check -------------------------------------------------
+# Exit 2 means packets are going out and nothing is coming back. That is a real
+# operational failure (poster inactive, mailbox misrouted, or parser drift) and
+# it is the exact condition that hid for a month.
+python3 "$INGEST" check --stale-hours "$STALE_HOURS" >> "$LOG" 2>&1
+CHECK_RC=$?
+
+if [ "$CHECK_RC" -eq 2 ]; then
+  STALE_COUNT=$(grep -oE "SYNDICATION GAP: [0-9]+" "$LOG" | tail -1 | grep -oE "[0-9]+")
+  log "SYNDICATION GAP: ${STALE_COUNT:-?} post(s) packeted with nothing recorded"
+  alert "${STALE_COUNT:-?} packeted post(s) have no recorded syndication after ${STALE_HOURS}h — poster inactive or replies not reaching the ingester"
+elif [ "$CHECK_RC" -ne 0 ]; then
+  log "check errored (rc=$CHECK_RC)"
+  alert "syndication check errored rc=$CHECK_RC"
+else
+  log "syndication loop healthy"
+fi
+
+# Liveness markers so the estate dead-man's-switch sees this schedule fire.
+if command -v liveness_markers >/dev/null 2>&1; then
+  liveness_markers "blog-syndication-ingest" 0
+else
+  mkdir -p "$HOME/.local/state/intent-os/liveness" 2>/dev/null || true
+  : > "$HOME/.local/state/intent-os/liveness/blog-syndication-ingest.beat" 2>/dev/null || true
+fi
+
+log "=== syndication ingest end ==="
+exit 0

--- a/scripts/blog/ingest-syndication-replies.py
+++ b/scripts/blog/ingest-syndication-replies.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Close the syndication loop: read Ezekiel's packet replies, record what shipped.
+
+THE GAP THIS FIXES
+------------------
+`references/ezekiel/02-daily-sop.md` tells the poster to reply to the packet
+email with the resulting URLs. Nothing ever read those replies, so every
+`syndication.*.status` in `.blog-syndication-ledger.json` stayed "pending"
+forever regardless of what actually got posted, and the Monday team rollup
+reported zero syndication as if nobody had done the work. The loop was
+open-ended by construction: packet out, nothing back in.
+
+Two modes:
+
+  ingest   Parse replies over IMAP and write recorded posts into the ledger.
+  check    Dead-man switch. Exit 2 if any post was packeted more than
+           --stale-hours ago and still has zero recorded destinations. This is
+           the alarm that would have caught the open loop weeks earlier.
+
+Deterministic and side-effect-light: stdlib only, read-only on the mailbox
+(never deletes or flags mail), atomic ledger writes, and it never downgrades a
+destination that is already recorded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import email
+import imaplib
+import json
+import os
+import re
+import ssl
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from email.header import decode_header, make_header
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+LEDGER = REPO / ".blog-syndication-ledger.json"
+ENV_FILE = Path.home() / "000-projects" / "intent-mail" / ".env"
+
+# Label -> ledger key. The SOP's example reply uses exactly these labels.
+LABEL_KEYS = [
+    (re.compile(r"^\s*[-*]?\s*linkedin\s+personal\b", re.I), "li_personal"),
+    (re.compile(r"^\s*[-*]?\s*linkedin\s+company\b", re.I), "li_company"),
+    (re.compile(r"^\s*[-*]?\s*(x|twitter)\b", re.I), "x"),
+    (re.compile(r"^\s*[-*]?\s*substack\b", re.I), "substack"),
+    (re.compile(r"^\s*[-*]?\s*medium\b", re.I), "medium"),
+]
+
+# Fallback when a reply omits labels: sniff the URL's host. LinkedIn is
+# deliberately absent here because /feed/update/ URLs do not distinguish a
+# personal post from a company one; guessing would write a wrong record, and a
+# wrong record is worse than an unrecorded one.
+HOST_KEYS = [
+    (re.compile(r"https?://(www\.)?(x|twitter)\.com/", re.I), "x"),
+    (re.compile(r"https?://[\w.-]*substack\.com/", re.I), "substack"),
+    (re.compile(r"https?://(www\.)?medium\.com/", re.I), "medium"),
+]
+
+URL_RE = re.compile(r"https?://[^\s<>\)\]\"']+")
+POSTED_DATE_RE = re.compile(r"\bposted\s+(\d{4}-\d{2}-\d{2})", re.I)
+DESTINATIONS = ("x", "li_personal", "li_company", "substack", "medium")
+
+
+def load_env() -> dict:
+    """Read SMTP_* from intent-mail's .env. Values never printed."""
+    env = {}
+    if ENV_FILE.exists():
+        for line in ENV_FILE.read_text(errors="replace").splitlines():
+            m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", line.strip())
+            if m:
+                env[m.group(1)] = m.group(2).strip().strip('"').strip("'")
+    for k in ("SMTP_HOST", "SMTP_USER", "SMTP_PASS"):
+        if os.environ.get(k):
+            env[k] = os.environ[k]
+    return env
+
+
+def load_ledger() -> list:
+    if not LEDGER.exists():
+        return []
+    with LEDGER.open() as fh:
+        return json.load(fh)
+
+
+def write_ledger(entries: list) -> None:
+    """Atomic write. A half-written ledger would strand every future sweep."""
+    LEDGER.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(LEDGER.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(entries, fh, indent=2)
+            fh.write("\n")
+        json.loads(Path(tmp).read_text())  # parse-gate before it goes live
+        os.replace(tmp, LEDGER)
+    except Exception:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def body_text(msg: email.message.Message) -> str:
+    """Prefer text/plain; fall back to de-tagged HTML."""
+    parts = []
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                parts.append(part.get_payload(decode=True) or b"")
+    else:
+        parts.append(msg.get_payload(decode=True) or b"")
+    text = b"\n".join(parts).decode("utf-8", errors="replace")
+    if text.strip():
+        return text
+    html = []
+    for part in (msg.walk() if msg.is_multipart() else [msg]):
+        if part.get_content_type() == "text/html":
+            html.append((part.get_payload(decode=True) or b"").decode("utf-8", "replace"))
+    return re.sub(r"<[^>]+>", " ", "\n".join(html))
+
+
+def parse_reply(text: str) -> dict:
+    """Extract {destination: url} from a reply body.
+
+    Label lines win over host sniffing so an X link pasted on the LinkedIn line
+    is recorded the way the human labelled it.
+    """
+    found = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        urls = URL_RE.findall(line)
+        if not urls:
+            continue
+        url = urls[0].rstrip(".,;")
+        for pattern, key in LABEL_KEYS:
+            if pattern.search(line):
+                found.setdefault(key, url)
+                break
+        else:
+            for pattern, key in HOST_KEYS:
+                if pattern.search(url):
+                    found.setdefault(key, url)
+                    break
+    return found
+
+
+def match_entry(entries: list, subject: str, text: str) -> dict | None:
+    """Tie a reply to a ledger post: explicit date, then canonical URL, then title."""
+    m = POSTED_DATE_RE.search(text)
+    if m:
+        for e in entries:
+            if e.get("date") == m.group(1):
+                return e
+    for e in entries:
+        canonical = e.get("canonical_url")
+        if canonical and canonical.rstrip("/") in text:
+            return e
+    hay = f"{subject} {text}".lower()
+    best = None
+    for e in entries:
+        title = (e.get("title") or "").lower()
+        if len(title) > 12 and title in hay:
+            if best is None or len(title) > len(best.get("title") or ""):
+                best = e
+    return best
+
+
+def fetch_replies(env: dict, days: int, sender: str) -> list:
+    host = env.get("SMTP_HOST")
+    user = env.get("SMTP_USER")
+    password = env.get("SMTP_PASS")
+    if not (host and user and password):
+        raise SystemExit("FATAL: SMTP_HOST/SMTP_USER/SMTP_PASS unavailable")
+
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%d-%b-%Y")
+    out = []
+    conn = imaplib.IMAP4_SSL(host, 993, ssl_context=ssl.create_default_context())
+    try:
+        conn.login(user, password)
+        conn.select("INBOX", readonly=True)  # readonly: never mutate the mailbox
+        criteria = ["SINCE", since]
+        if sender:
+            criteria += ["FROM", sender]
+        typ, data = conn.search(None, *criteria)
+        if typ != "OK":
+            return out
+        for num in (data[0].split() if data and data[0] else []):
+            typ, raw = conn.fetch(num, "(RFC822)")
+            if typ != "OK" or not raw or not raw[0]:
+                continue
+            msg = email.message_from_bytes(raw[0][1])
+            subject = str(make_header(decode_header(msg.get("Subject") or "")))
+            out.append({"subject": subject, "from": msg.get("From") or "", "text": body_text(msg)})
+    finally:
+        try:
+            conn.logout()
+        except Exception:
+            pass
+    return out
+
+
+def cmd_ingest(args) -> int:
+    entries = load_ledger()
+    if not entries:
+        print("ledger empty; nothing to reconcile")
+        return 0
+
+    replies = fetch_replies(load_env(), args.days, args.sender)
+    print(f"scanned {len(replies)} message(s) from {args.sender or 'anyone'} in the last {args.days}d")
+
+    updated, unmatched = 0, 0
+    now = datetime.now(timezone.utc).isoformat()
+    for reply in replies:
+        found = parse_reply(reply["text"])
+        if not found:
+            continue
+        entry = match_entry(entries, reply["subject"], reply["text"])
+        if entry is None:
+            unmatched += 1
+            print(f"  UNMATCHED reply: {reply['subject'][:70]}")
+            continue
+        syn = entry.setdefault("syndication", {})
+        for key, url in found.items():
+            slot = syn.setdefault(key, {})
+            if slot.get("status") == "posted":
+                continue  # never overwrite an existing record
+            if slot.get("status") == "n/a":
+                continue  # tier says this destination does not apply
+            slot.update({
+                "status": "posted",
+                "posted_at": now,
+                "url": url,
+                "by": (reply["from"] or "").split("<")[-1].rstrip(">") or "reply",
+            })
+            updated += 1
+            print(f"  {entry.get('date')} {key} -> posted")
+
+    if updated and not args.dry_run:
+        write_ledger(entries)
+        print(f"ledger updated: {updated} destination(s) recorded")
+    elif updated:
+        print(f"DRY-RUN: would record {updated} destination(s)")
+    else:
+        print("no new destinations to record")
+    if unmatched:
+        print(f"NOTE: {unmatched} reply/replies could not be tied to a post")
+    return 0
+
+
+def cmd_check(args) -> int:
+    """Dead-man switch: packeted long ago, still nothing recorded."""
+    entries = load_ledger()
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=args.stale_hours)
+    stale = []
+    for e in entries:
+        if not e.get("packet_sent"):
+            continue
+        published = e.get("published_at") or ""
+        try:
+            when = datetime.fromisoformat(published)
+            if when.tzinfo is None:
+                when = when.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        if when > cutoff:
+            continue
+        syn = e.get("syndication") or {}
+        live = [k for k in DESTINATIONS
+                if (syn.get(k) or {}).get("status") not in (None, "pending", "n/a")]
+        if not live:
+            stale.append(e)
+
+    if not stale:
+        print("syndication loop healthy: every packeted post has at least one recorded destination")
+        return 0
+
+    print(f"SYNDICATION GAP: {len(stale)} packeted post(s) with nothing recorded "
+          f"after {args.stale_hours}h")
+    for e in stale:
+        print(f"  {e.get('date')}  {e.get('slug')}")
+    print("Either the poster is not posting, or replies are not reaching the ingester.")
+    return 2
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    ing = sub.add_parser("ingest", help="parse packet replies and record posted URLs")
+    ing.add_argument("--days", type=int, default=14)
+    ing.add_argument("--sender", default="ezekiel@intentsolutions.io",
+                     help="restrict to this sender; empty string scans all")
+    ing.add_argument("--dry-run", action="store_true")
+    ing.set_defaults(func=cmd_ingest)
+
+    chk = sub.add_parser("check", help="alert when packeted posts have nothing recorded")
+    chk.add_argument("--stale-hours", type=int, default=48)
+    chk.set_defaults(func=cmd_check)
+
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/blog/ingest-syndication-replies.py
+++ b/scripts/blog/ingest-syndication-replies.py
@@ -35,6 +35,7 @@ import sys
 import tempfile
 from datetime import datetime, timedelta, timezone
 from email.header import decode_header, make_header
+from email.utils import parseaddr
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
@@ -147,6 +148,21 @@ def parse_reply(text: str) -> dict:
     return found
 
 
+def actor(from_header: str) -> str:
+    """Bare address from a From header, or 'reply' if it is not a clean address.
+
+    Splitting on '<' persisted whatever the header happened to contain: a
+    display-name-only From ("Ezekiel Smith") stored the display name, and a
+    malformed or spoofed header stored its raw text straight into the ledger.
+    parseaddr does the RFC parse; the shape check refuses anything that is not
+    recognisably an address rather than recording an attacker-controlled string.
+    """
+    _, addr = parseaddr(from_header or "")
+    if addr and re.fullmatch(r"[^@\s<>\"]+@[^@\s<>\"]+\.[^@\s<>\"]+", addr):
+        return addr
+    return "reply"
+
+
 def match_entry(entries: list, subject: str, text: str) -> dict | None:
     """Tie a reply to a ledger post: explicit date, then canonical URL, then title."""
     m = POSTED_DATE_RE.search(text)
@@ -154,10 +170,23 @@ def match_entry(entries: list, subject: str, text: str) -> dict | None:
         for e in entries:
             if e.get("date") == m.group(1):
                 return e
+
+    # Canonical match must be boundary-anchored and longest-wins. A plain
+    # substring test mis-attributes whenever one slug prefixes another:
+    # ".../posts/foo" is a substring of ".../posts/foo-part-2", so a reply
+    # about part 2 would be recorded against post one. Requiring the next
+    # character to be a non-slug character (not [A-Za-z0-9_-]) rejects that
+    # while still allowing a trailing slash, query string, or end of line.
+    best, best_len = None, -1
     for e in entries:
-        canonical = e.get("canonical_url")
-        if canonical and canonical.rstrip("/") in text:
-            return e
+        canonical = (e.get("canonical_url") or "").rstrip("/")
+        if not canonical:
+            continue
+        if re.search(re.escape(canonical) + r"(?![A-Za-z0-9_-])", text):
+            if len(canonical) > best_len:
+                best, best_len = e, len(canonical)
+    if best is not None:
+        return best
     hay = f"{subject} {text}".lower()
     best = None
     for e in entries:
@@ -233,7 +262,7 @@ def cmd_ingest(args) -> int:
                 "status": "posted",
                 "posted_at": now,
                 "url": url,
-                "by": (reply["from"] or "").split("<")[-1].rstrip(">") or "reply",
+                "by": actor(reply["from"]),
             })
             updated += 1
             print(f"  {entry.get('date')} {key} -> posted")


### PR DESCRIPTION
## What

Adds the missing half of the syndication feedback loop, plus a dead-man switch on it.

- `scripts/blog/ingest-syndication-replies.py` — reads the poster's packet replies over IMAP and records the real posted URLs into `.blog-syndication-ledger.json`.
- `scripts/blog/blog-syndication-ingest.sh` — cron wrapper: ingest, then a staleness check that alerts through the governed Buzz dispatch.

## Why

`references/ezekiel/02-daily-sop.md:17` tells the poster to reply to each packet email with the resulting URLs. **Nothing on our side ever read those replies.** Every `syndication.*.status` stayed `pending` forever no matter what was actually posted, and the Monday team rollup reported zero syndication as if nobody had done the work.

Measured against the live ledger today: **29 packeted posts back to 2026-07-05 with no recorded destination.** The loop was open by construction *and* had no alarm, so a month of silence looked identical to a month of inactivity.

**Chose a dead-man check over trusting ingest to be self-evidencing**, because the exact failure being fixed was a silent one — an ingester that quietly finds nothing reproduces the original bug.

## Layer(s) touched

Syndication layer only (post-publication). **No change to the produce → land → deploy path**: nothing here runs before or during `blog-land.sh`, and no publication invariant is altered. The ledger gains populated values in an existing schema field; no schema change, no new field.

## How it works

Reply matching is layered, most-explicit first: the SOP's `Posted YYYY-MM-DD` line → canonical-URL match → title match. Destination labels (`- LinkedIn personal: <url>`) win over URL-host sniffing, so a link pasted on the wrong line is recorded as the human labelled it.

**Deliberate refusal:** an unlabelled `linkedin.com/feed/update/...` URL cannot distinguish personal from company, so it is left unrecorded rather than guessed. A wrong attribution is worse than an absent one.

Safety: mailbox opened `readonly` (never flags or deletes mail), existing records never overwritten, `n/a` destinations never written, ledger written atomically via temp file + JSON parse-gate before `os.replace`.

## Verification & evidence

| Check | Result |
|---|---|
| `python3 -m py_compile` | clean |
| `bash -n` on wrapper | clean |
| Parser vs the SOP's verbatim example reply | all 5 destinations extracted; personal/company **not** transposed |
| Parser vs an unlabelled reply | records `x` + `medium`; **correctly declines** LinkedIn |
| `check` mode vs live ledger | reproduces the 29-post gap, exit 2 |
| `ingest --dry-run` | real IMAP round-trip to MXroute completes; 0 replies exist — itself the finding |
| CI | shellcheck / ruff / hugo build on this PR |

## Risk assessment

Low, internal-only. Both scripts are **additive and wired to no schedule in this PR**, so merging changes no running behavior. No public API or contract. Backward-compatible: reads an existing ledger shape and only fills `pending` slots. Worst case it records nothing, which is today's status quo.

## Operational impact

- **Deps:** none — Python stdlib only (`imaplib`, `email`), no new packages.
- **Secrets:** reuses existing `SMTP_HOST`/`SMTP_USER`/`SMTP_PASS` from `intent-mail/.env`; no new credential, none logged.
- **Env/migrations:** none. **Cost:** none. **Deploy order:** irrelevant, not on the deploy path.

## Rollback

`git revert` this PR, or simply delete the two scripts — nothing references them until the cron follow-up lands. No state to unwind; any ledger entries already recorded remain valid and were user-confirmed URLs.

## Follow-up & deferred

- **`startaitools-v8j`** (P1) — wire cron (daily ingest before the 05:00 packet sweep; dead-man before the Monday 08:00 rollup), register in intent-os `mission-control/automations.md` so the weekly registry reconcile does not flag it as an orphan, decide disposition of the 29 historical posts, and confirm whether `ezekiel@intentsolutions.io` is a live MXroute mailbox post-cutover given that **zero replies have ever arrived**.
- **`startaitools-fmj`** (P1, pre-existing) — the Caddy soft-404 makes `blog-land.sh`'s liveness gate return 200 for a failed deploy. Observed again today on this same post: the lander logged `Liveness OK (after 0s)` while the site was still serving the homepage fallback.

## Governance

- Poster SOP: `~/.claude/skills/blog-backfill/references/ezekiel/02-daily-sop.md`
- Ledger contract: repo `CLAUDE.md` § "Cross-Posting + Syndication (WS2/WS3)"