### PR TITLE
feat(syndication): give the dead-man check hysteresis so it can run daily

### DIFF
--- a/scripts/blog/blog-syndication-ingest.sh
+++ b/scripts/blog/blog-syndication-ingest.sh
@@ -62,23 +62,35 @@ else
   alert "reply ingest failed rc=$rc; see $LOG"
 fi
 
-# --- Pass 2: dead-man check -------------------------------------------------
-# Exit 2 means packets are going out and nothing is coming back. That is a real
-# operational failure (poster inactive, mailbox misrouted, or parser drift) and
-# it is the exact condition that hid for a month.
+# --- Pass 2: dead-man check (hysteresis) ------------------------------------
+# Packets going out with nothing coming back is a real operational failure
+# (poster inactive, mailbox misrouted, or parser drift) and is exactly the
+# condition that hid for a month. Exit contract mirrors blog-tier-creep-guard:
+#   0 silent (healthy, or a persistent breach already alerted)
+#   1 ALERT  (onset or worsening)
+#   3 RECOVER (one-time all-clear)
+# Hysteresis is why this is safe to run daily: a known-broken state that has
+# not worsened stays quiet instead of paging every morning.
 python3 "$INGEST" check --stale-hours "$STALE_HOURS" >> "$LOG" 2>&1
 CHECK_RC=$?
 
-if [ "$CHECK_RC" -eq 2 ]; then
-  STALE_COUNT=$(grep -oE "SYNDICATION GAP: [0-9]+" "$LOG" | tail -1 | grep -oE "[0-9]+")
-  log "SYNDICATION GAP: ${STALE_COUNT:-?} post(s) packeted with nothing recorded"
-  alert "${STALE_COUNT:-?} packeted post(s) have no recorded syndication after ${STALE_HOURS}h — poster inactive or replies not reaching the ingester"
-elif [ "$CHECK_RC" -ne 0 ]; then
-  log "check errored (rc=$CHECK_RC)"
-  alert "syndication check errored rc=$CHECK_RC"
-else
-  log "syndication loop healthy"
-fi
+case "$CHECK_RC" in
+  0)
+    log "check silent (healthy, or persistent gap suppressed by hysteresis)"
+    ;;
+  1)
+    STALE_COUNT=$(grep -oE "SYNDICATION GAP: [0-9]+" "$LOG" | tail -1 | grep -oE "[0-9]+")
+    log "ALERT: syndication gap onset/worsening (${STALE_COUNT:-?} post(s))"
+    alert "${STALE_COUNT:-?} packeted post(s) have no recorded syndication after ${STALE_HOURS}h (onset/worsening) — poster inactive or replies not reaching the ingester"
+    ;;
+  3)
+    log "RECOVERED: syndication gap cleared"
+    ;;
+  *)
+    log "check errored (rc=$CHECK_RC)"
+    alert "syndication check errored rc=$CHECK_RC"
+    ;;
+esac
 
 # Liveness markers so the estate dead-man's-switch sees this schedule fire.
 if command -v liveness_markers >/dev/null 2>&1; then

--- a/scripts/blog/ingest-syndication-replies.py
+++ b/scripts/blog/ingest-syndication-replies.py
@@ -279,8 +279,42 @@ def cmd_ingest(args) -> int:
     return 0
 
 
+STATE_FILE = Path.home() / ".local" / "state" / "blog-syndication-ingest" / "state.json"
+
+
+def load_state() -> dict:
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except Exception:
+        return {}
+
+
+def save_state(state: dict) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(STATE_FILE.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(state, fh, indent=2)
+            fh.write("\n")
+        os.replace(tmp, STATE_FILE)
+    except Exception:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
 def cmd_check(args) -> int:
-    """Dead-man switch: packeted long ago, still nothing recorded."""
+    """Dead-man switch: packeted long ago, still nothing recorded.
+
+    Exit contract mirrors blog-tier-creep-guard (the estate's existing
+    hysteresis precedent), so this can run daily without becoming a nag:
+
+      0  silent   healthy, OR a breach that merely persists at its known size
+      1  ALERT    breach onset, or worsening past the recorded high-water mark
+      3  RECOVER  was breached, now clean (one-time all-clear)
+
+    State lives outside the repo so a guard run never dirties the working tree
+    and trips the lander's clean-tree precondition.
+    """
     entries = load_ledger()
     cutoff = datetime.now(timezone.utc) - timedelta(hours=args.stale_hours)
     stale = []
@@ -302,16 +336,39 @@ def cmd_check(args) -> int:
         if not live:
             stale.append(e)
 
-    if not stale:
+    count = len(stale)
+    if count:
+        print(f"SYNDICATION GAP: {count} packeted post(s) with nothing recorded "
+              f"after {args.stale_hours}h")
+        for e in stale:
+            print(f"  {e.get('date')}  {e.get('slug')}")
+        print("Either the poster is not posting, or replies are not reaching the ingester.")
+    else:
         print("syndication loop healthy: every packeted post has at least one recorded destination")
+
+    # Stateless: report only, never read or write the high-water mark. This is
+    # the mode for a human running it by hand mid-incident.
+    if args.stateless:
+        return 2 if count else 0
+
+    state = load_state()
+    high_water = int(state.get("high_water", 0))
+
+    if count == 0:
+        if high_water > 0:
+            save_state({"high_water": 0, "recovered_at": datetime.now(timezone.utc).isoformat()})
+            print("RECOVERED: the gap has cleared")
+            return 3
         return 0
 
-    print(f"SYNDICATION GAP: {len(stale)} packeted post(s) with nothing recorded "
-          f"after {args.stale_hours}h")
-    for e in stale:
-        print(f"  {e.get('date')}  {e.get('slug')}")
-    print("Either the poster is not posting, or replies are not reaching the ingester.")
-    return 2
+    if count > high_water:
+        save_state({"high_water": count,
+                    "alerted_at": datetime.now(timezone.utc).isoformat()})
+        print(f"ALERT: gap onset/worsening ({high_water} -> {count})")
+        return 1
+
+    print(f"silent: gap persists at {count} (high-water {high_water}), suppressed by hysteresis")
+    return 0
 
 
 def main() -> int:
@@ -328,6 +385,8 @@ def main() -> int:
 
     chk = sub.add_parser("check", help="alert when packeted posts have nothing recorded")
     chk.add_argument("--stale-hours", type=int, default=48)
+    chk.add_argument("--stateless", action="store_true",
+                     help="report only; do not read or update the hysteresis high-water mark")
     chk.set_defaults(func=cmd_check)
 
     args = ap.parse_args()

--- a/scripts/blog/ingest-syndication-replies.py
+++ b/scripts/blog/ingest-syndication-replies.py
@@ -283,10 +283,18 @@ STATE_FILE = Path.home() / ".local" / "state" / "blog-syndication-ingest" / "sta
 
 
 def load_state() -> dict:
+    """Always hand back a dict.
+
+    json.loads happily returns a list, string or number for a file that is
+    valid JSON but not an object, and every caller then does .get() on it and
+    raises. A guard that crashes on its own state file is a guard that is
+    silently absent, so anything not an object degrades to empty.
+    """
     try:
-        return json.loads(STATE_FILE.read_text())
+        data = json.loads(STATE_FILE.read_text())
     except Exception:
         return {}
+    return data if isinstance(data, dict) else {}
 
 
 def save_state(state: dict) -> None:

--- a/scripts/blog/ingest-syndication-replies.py
+++ b/scripts/blog/ingest-syndication-replies.py
@@ -352,20 +352,39 @@ def cmd_check(args) -> int:
         return 2 if count else 0
 
     state = load_state()
-    high_water = int(state.get("high_water", 0))
+    # A state file that is valid JSON but holds a non-integer marker (null, a
+    # string, a hand-edit) must not wedge every future scheduled run. Degrade
+    # to 0: the worst case is one re-alert, versus a guard that crashes daily
+    # and is therefore silently absent, which is the failure class this whole
+    # change exists to prevent.
+    try:
+        high_water = int(state.get("high_water", 0))
+    except (TypeError, ValueError):
+        print("WARN: unreadable high_water in state; treating as 0")
+        high_water = 0
+    high_water = max(high_water, 0)
+
+    now = datetime.now(timezone.utc).isoformat()
 
     if count == 0:
         if high_water > 0:
-            save_state({"high_water": 0, "recovered_at": datetime.now(timezone.utc).isoformat()})
+            save_state({"high_water": 0, "recovered_at": now})
             print("RECOVERED: the gap has cleared")
             return 3
         return 0
 
     if count > high_water:
-        save_state({"high_water": count,
-                    "alerted_at": datetime.now(timezone.utc).isoformat()})
+        save_state({"high_water": count, "alerted_at": now})
         print(f"ALERT: gap onset/worsening ({high_water} -> {count})")
         return 1
+
+    if count < high_water:
+        # Ratchet the mark DOWN on improvement. Holding an all-time high would
+        # mean a partial recovery (29 -> 3) silently swallows a real regression
+        # back up to 10, because 10 < 29 still reads as "persistent".
+        save_state({"high_water": count, "improved_at": now})
+        print(f"silent: gap improved to {count} (mark lowered from {high_water})")
+        return 0
 
     print(f"silent: gap persists at {count} (high-water {high_water}), suppressed by hysteresis")
     return 0


### PR DESCRIPTION
## What
Adds hysteresis to the syndication dead-man check so it is safe to schedule daily, and adopts the estate's existing guard exit contract.

## Why
Wiring the guard from #60 to a daily cron as written would page every morning about the same 29-post gap until the poster question is settled — the exact nag pattern `blog-tier-creep-guard.sh` already solved.

**Chose daily-with-hysteresis over a weekly schedule** because weekly would delay detection of a *new* break by up to seven days; daily catches onset next morning while staying silent on a known state.

## Layer(s) touched
Syndication guard only. No change to produce → land → deploy. Guard state lives **outside the repo** (`~/.local/state/blog-syndication-ingest/state.json`) so a run can never dirty the tree and trip the lander's clean-tree precondition.

## How it works
Exit contract now mirrors `blog-tier-creep-guard`:

| rc | Meaning |
|----|---------|
| 0 | silent — healthy, or a breach persisting at its known size |
| 1 | ALERT — onset, or worsening past the high-water mark |
| 3 | RECOVER — one-time all-clear |

`--stateless` added for a human running it mid-incident: reports, touches no state. Same flag name as tier-creep-guard.

## Verification & evidence
- `py_compile` + `bash -n` clean.
- Exit codes exercised end to end against the **live** ledger: onset `rc=1`, persist `rc=0`, `--stateless` `rc=2`, state provably unchanged by the stateless run.
- Simulated clean ledger: `rc=3` once, then `rc=0` — recovery fires exactly once.
- High-water **pre-armed at the current gap (29)**, so the first scheduled run is silent rather than a false alert.
- CI: shellcheck / ruff / hugo build / voice-lint.

## Risk assessment
Low, internal-only. Still wired to no schedule in this PR. Worst case the guard is silent when it should speak, which is today's status quo (it has never run on a schedule). No public API or contract; backward compatible with the ledger shape.

## Operational impact
None: no deps, no secrets, no migrations, no cost, not on the deploy path. Creates one small JSON state file under `~/.local/state/`.

## Rollback
`git revert`; or delete the state file to reset the high-water mark. Nothing else references it until cron wiring lands.

## Follow-up & deferred
- **`startaitools-v8j`** — cron wiring itself, registration in intent-os `mission-control/automations.md` (else the weekly registry reconcile flags it as an orphan), disposition of the 29 historical posts, and confirming whether `ezekiel@intentsolutions.io` survived the Workspace→MXroute cutover given that **zero replies have ever arrived**.

## Governance
- Hysteresis precedent: `scripts/blog/blog-tier-creep-guard.sh`, `.claude/skills/blog-backfill/scripts/tier-creep-guard.py`
- Repo `CLAUDE.md` § "Autonomous Daily Automation"

Refs #60