### PR TITLE
fix(syndication): corroborate against UTM before the guard blames the poster

### DIFF
--- a/scripts/blog/ingest-syndication-replies.py
+++ b/scripts/blog/ingest-syndication-replies.py
@@ -15,6 +15,10 @@ Two modes:
   ingest   Parse replies over IMAP and write recorded posts into the ledger.
   check    Dead-man switch, corroborated against UTM. Exit contract mirrors
            blog-tier-creep-guard: 0 silent, 1 onset/worsening, 3 recovered.
+           `--stateless` is the exception: it reports without touching the
+           hysteresis mark and returns 2 when a gap exists, 0 when clean, so
+           a human can inspect mid-incident without disarming the scheduled
+           guard. Cron must therefore never pass --stateless.
 
 WHAT `check` ACTUALLY MEASURES
 ------------------------------
@@ -297,6 +301,7 @@ def cmd_ingest(args) -> int:
 STATE_FILE = Path.home() / ".local" / "state" / "blog-syndication-ingest" / "state.json"
 HOME_ENV = Path.home() / ".env"
 UMAMI_SITE = "4071f4db-4249-4ce6-a929-665598975d67"  # startaitools.com
+UMAMI_ROW_LIMIT = 500
 
 
 def utm_arrivals(days: int) -> int | None:
@@ -339,9 +344,23 @@ def utm_arrivals(days: int) -> int | None:
             return None
         end = int(datetime.now(UTC).timestamp() * 1000)
         start = end - days * 86400 * 1000
+        # Umami returns one row per distinct query string, and UTM campaigns
+        # multiply those fast (utm_source alone, +medium, +campaign, plus
+        # LinkedIn's own trk= prefix all count separately). A low cap would
+        # silently truncate and undercount the very number the verdict rests
+        # on, so ask for far more rows than the tail can plausibly reach.
         rows = post_json(
-            f"/api/websites/{UMAMI_SITE}/metrics?startAt={start}&endAt={end}&type=query&limit=100",
+            f"/api/websites/{UMAMI_SITE}/metrics"
+            f"?startAt={start}&endAt={end}&type=query&limit={UMAMI_ROW_LIMIT}",
             None, token)
+        if not isinstance(rows, list):
+            return None
+        if len(rows) >= UMAMI_ROW_LIMIT:
+            # Truncated: the sum is a floor, not a total. It can only be an
+            # undercount, so a positive verdict stays sound; say so rather
+            # than report a number we cannot stand behind.
+            print(f"NOTE: Umami returned {len(rows)} rows (cap reached); "
+                  "UTM count below is a lower bound")
         return sum(r.get("y", 0) for r in rows if "utm_source" in (r.get("x") or ""))
     except Exception:
         return None
@@ -430,24 +449,35 @@ def cmd_check(args) -> int:
     # first-comment placement. A guard that reads only the ledger would have
     # paged "poster inactive" about someone doing the job properly.
     utm = utm_arrivals(args.utm_days) if count and not args.no_utm else None
+    utm_confirms = False
     if count and utm is not None:
         print(f"UTM corroboration: {utm} tagged arrival(s) in the last {args.utm_days}d")
         if utm > 0:
+            utm_confirms = True
             print("VERDICT: recording gap only — syndication is demonstrably live. "
                   "The poster is working; the reply-to-ledger path is what is missing.")
-            if not args.stateless:
-                save_state({"high_water": count, "utm_confirmed_at": now_iso(),
-                            "utm_arrivals": utm})
-            return 0
-        print("VERDICT: no ledger records AND no UTM arrivals — syndication may have stopped.")
-    elif count:
-        print("UTM corroboration unavailable; reasoning from the ledger alone. "
+        else:
+            print("VERDICT: no ledger records AND no UTM arrivals — syndication may have stopped.")
+    elif count and args.no_utm:
+        print("UTM corroboration disabled by --no-utm; reasoning from the ledger alone. "
               "Absence of a record is not evidence that nothing was posted.")
+    elif count:
+        print("UTM corroboration UNAVAILABLE (Umami unreachable); reasoning from the "
+              "ledger alone. Absence of a record is not evidence that nothing was posted.")
 
     # Stateless: report only, never read or write the high-water mark. This is
-    # the mode for a human running it by hand mid-incident.
+    # the mode for a human running it by hand mid-incident, so it answers the
+    # literal question asked ("is anything unrecorded?") and is evaluated
+    # BEFORE the UTM-informed returns below. Letting the UTM branch preempt it
+    # made --stateless report 0 while a gap existed, contradicting its own
+    # contract. Cron must never pass --stateless: it would disarm hysteresis.
     if args.stateless:
         return 2 if count else 0
+
+    if utm_confirms:
+        save_state({"high_water": count, "utm_confirmed_at": now_iso(),
+                    "utm_arrivals": utm})
+        return 0
 
     state = load_state()
     # A state file that is valid JSON but holds a non-integer marker (null, a

--- a/scripts/blog/ingest-syndication-replies.py
+++ b/scripts/blog/ingest-syndication-replies.py
@@ -344,6 +344,14 @@ def utm_arrivals(days: int) -> int | None:
             return None
         end = int(datetime.now(UTC).timestamp() * 1000)
         start = end - days * 86400 * 1000
+        # type=query is deliberate and load-bearing. DO NOT "correct" this to
+        # type=utm_source: that type returns HTTP 400 on this Umami version.
+        # With type=query each row's `x` is the FULL query string, verified
+        # live 2026-08-06:
+        #     {"x": "trk=public_post_comment-text&utm_source=linkedin", "y": 16}
+        #     {"x": "utm_source=x", "y": 7}
+        # which is why the substring test below is correct rather than a bug.
+        #
         # Umami returns one row per distinct query string, and UTM campaigns
         # multiply those fast (utm_source alone, +medium, +campaign, plus
         # LinkedIn's own trk= prefix all count separately). A low cap would
@@ -474,12 +482,21 @@ def cmd_check(args) -> int:
     if args.stateless:
         return 2 if count else 0
 
+    state = load_state()
+
     if utm_confirms:
-        save_state({"high_water": count, "utm_confirmed_at": now_iso(),
-                    "utm_arrivals": utm})
+        # Deliberately preserves the existing high_water instead of raising it
+        # to `count`. That mark is the ALARM baseline; arming it from a
+        # non-alarm would let this run mask the next one, because with Umami
+        # unreachable and the same count the gap would read as "persistent"
+        # and be silenced even though it could no longer be corroborated.
+        # Corroboration is recorded alongside, so it stays visible in state
+        # without suppressing anything.
+        state["utm_confirmed_at"] = now_iso()
+        state["utm_arrivals"] = utm
+        save_state(state)
         return 0
 
-    state = load_state()
     # A state file that is valid JSON but holds a non-integer marker (null, a
     # string, a hand-edit) must not wedge every future scheduled run. Degrade
     # to 0: the worst case is one re-alert, versus a guard that crashes daily

--- a/scripts/blog/ingest-syndication-replies.py
+++ b/scripts/blog/ingest-syndication-replies.py
@@ -13,13 +13,27 @@ open-ended by construction: packet out, nothing back in.
 Two modes:
 
   ingest   Parse replies over IMAP and write recorded posts into the ledger.
-  check    Dead-man switch. Exit 2 if any post was packeted more than
-           --stale-hours ago and still has zero recorded destinations. This is
-           the alarm that would have caught the open loop weeks earlier.
+  check    Dead-man switch, corroborated against UTM. Exit contract mirrors
+           blog-tier-creep-guard: 0 silent, 1 onset/worsening, 3 recovered.
+
+WHAT `check` ACTUALLY MEASURES
+------------------------------
+The ledger measures BOOKKEEPING (did a reply email arrive). UTM measures WORK
+(did a reader actually arrive from a syndicated link). These are not the same
+signal, and conflating them is dangerous: on 2026-08-06 the ledger showed 29
+posts with nothing recorded while Umami showed 32 UTM-tagged arrivals, 16 of
+them carrying LinkedIn's `trk=public_post_comment-text` marker, which is proof
+the poster was placing links in the first comment exactly as the SOP requires.
+
+A ledger-only guard would have paged "poster inactive" about someone doing the
+job correctly. So `check` consults UTM before reaching any verdict, and only
+treats the situation as an alarm when the ledger is empty AND the traffic is
+too. Missing paperwork is a recording gap; missing traffic is an outage.
 
 Deterministic and side-effect-light: stdlib only, read-only on the mailbox
-(never deletes or flags mail), atomic ledger writes, and it never downgrades a
-destination that is already recorded.
+(never deletes or flags mail), atomic ledger writes, it never downgrades a
+destination that is already recorded, and a failed UTM query degrades to
+ledger-only reasoning rather than inventing a verdict.
 """
 
 from __future__ import annotations
@@ -241,7 +255,7 @@ def cmd_ingest(args) -> int:
     print(f"scanned {len(replies)} message(s) from {args.sender or 'anyone'} in the last {args.days}d")
 
     updated, unmatched = 0, 0
-    now = datetime.now(timezone.utc).isoformat()
+    now = now_iso()
     for reply in replies:
         found = parse_reply(reply["text"])
         if not found:
@@ -280,6 +294,60 @@ def cmd_ingest(args) -> int:
 
 
 STATE_FILE = Path.home() / ".local" / "state" / "blog-syndication-ingest" / "state.json"
+HOME_ENV = Path.home() / ".env"
+UMAMI_SITE = "4071f4db-4249-4ce6-a929-665598975d67"  # startaitools.com
+
+
+def utm_arrivals(days: int) -> int | None:
+    """Count UTM-tagged arrivals on startaitools.com over the window.
+
+    This is the ground truth the ledger cannot see. The ledger records only
+    what the poster emails back; UTM records what the internet actually did.
+    Conflating the two is how an absent reply becomes an accusation that
+    nobody posted.
+
+    Returns None when Umami cannot be reached, so the caller degrades to
+    ledger-only reasoning instead of inventing a verdict from a failed query.
+    """
+    try:
+        import urllib.request
+
+        env = {}
+        if HOME_ENV.exists():
+            for line in HOME_ENV.read_text(errors="replace").splitlines():
+                m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", line.strip())
+                if m:
+                    env[m.group(1)] = m.group(2).strip().strip('"').strip("'")
+        url = env.get("UMAMI_URL") or "https://analytics.intentsolutions.io"
+        user, pw = env.get("UMAMI_USERNAME"), env.get("UMAMI_PASSWORD")
+        if not (user and pw):
+            return None
+
+        def post_json(path, payload, token=None):
+            req = urllib.request.Request(
+                url.rstrip("/") + path,
+                data=json.dumps(payload).encode() if payload is not None else None,
+                headers={"Content-Type": "application/json",
+                         **({"Authorization": f"Bearer {token}"} if token else {})},
+                method="POST" if payload is not None else "GET")
+            with urllib.request.urlopen(req, timeout=15) as r:
+                return json.loads(r.read())
+
+        token = post_json("/api/auth/login", {"username": user, "password": pw}).get("token")
+        if not token:
+            return None
+        end = int(datetime.now(timezone.utc).timestamp() * 1000)
+        start = end - days * 86400 * 1000
+        rows = post_json(
+            f"/api/websites/{UMAMI_SITE}/metrics?startAt={start}&endAt={end}&type=query&limit=100",
+            None, token)
+        return sum(r.get("y", 0) for r in rows if "utm_source" in (r.get("x") or ""))
+    except Exception:
+        return None
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def load_state() -> dict:
@@ -346,13 +414,34 @@ def cmd_check(args) -> int:
 
     count = len(stale)
     if count:
-        print(f"SYNDICATION GAP: {count} packeted post(s) with nothing recorded "
+        print(f"UNRECORDED: {count} packeted post(s) with no destination in the ledger "
               f"after {args.stale_hours}h")
         for e in stale:
             print(f"  {e.get('date')}  {e.get('slug')}")
-        print("Either the poster is not posting, or replies are not reaching the ingester.")
     else:
         print("syndication loop healthy: every packeted post has at least one recorded destination")
+
+    # Corroborate against UTM before drawing any conclusion about the poster.
+    # The ledger measures BOOKKEEPING (did a reply arrive); UTM measures WORK
+    # (did the internet arrive from a syndicated link). On 2026-08-06 those two
+    # diverged completely: 29 posts unrecorded while 32 UTM-tagged arrivals
+    # proved syndication was live and correct, including LinkedIn
+    # first-comment placement. A guard that reads only the ledger would have
+    # paged "poster inactive" about someone doing the job properly.
+    utm = utm_arrivals(args.utm_days) if count and not args.no_utm else None
+    if count and utm is not None:
+        print(f"UTM corroboration: {utm} tagged arrival(s) in the last {args.utm_days}d")
+        if utm > 0:
+            print("VERDICT: recording gap only — syndication is demonstrably live. "
+                  "The poster is working; the reply-to-ledger path is what is missing.")
+            if not args.stateless:
+                save_state({"high_water": count, "utm_confirmed_at": now_iso(),
+                            "utm_arrivals": utm})
+            return 0
+        print("VERDICT: no ledger records AND no UTM arrivals — syndication may have stopped.")
+    elif count:
+        print("UTM corroboration unavailable; reasoning from the ledger alone. "
+              "Absence of a record is not evidence that nothing was posted.")
 
     # Stateless: report only, never read or write the high-water mark. This is
     # the mode for a human running it by hand mid-incident.
@@ -412,6 +501,10 @@ def main() -> int:
 
     chk = sub.add_parser("check", help="alert when packeted posts have nothing recorded")
     chk.add_argument("--stale-hours", type=int, default=48)
+    chk.add_argument("--utm-days", type=int, default=30,
+                     help="window for the UTM corroboration query")
+    chk.add_argument("--no-utm", action="store_true",
+                     help="skip UTM corroboration (ledger-only reasoning)")
     chk.add_argument("--stateless", action="store_true",
                      help="report only; do not read or update the hysteresis high-water mark")
     chk.set_defaults(func=cmd_check)

--- a/scripts/blog/ingest-syndication-replies.py
+++ b/scripts/blog/ingest-syndication-replies.py
@@ -47,7 +47,7 @@ import re
 import ssl
 import sys
 import tempfile
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from email.header import decode_header, make_header
 from email.utils import parseaddr
 from pathlib import Path
@@ -218,7 +218,7 @@ def fetch_replies(env: dict, days: int, sender: str) -> list:
     if not (host and user and password):
         raise SystemExit("FATAL: SMTP_HOST/SMTP_USER/SMTP_PASS unavailable")
 
-    since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%d-%b-%Y")
+    since = (datetime.now(UTC) - timedelta(days=days)).strftime("%d-%b-%Y")
     out = []
     conn = imaplib.IMAP4_SSL(host, 993, ssl_context=ssl.create_default_context())
     try:
@@ -252,7 +252,8 @@ def cmd_ingest(args) -> int:
         return 0
 
     replies = fetch_replies(load_env(), args.days, args.sender)
-    print(f"scanned {len(replies)} message(s) from {args.sender or 'anyone'} in the last {args.days}d")
+    print(f"scanned {len(replies)} message(s) from "
+          f"{args.sender or 'anyone'} in the last {args.days}d")
 
     updated, unmatched = 0, 0
     now = now_iso()
@@ -336,7 +337,7 @@ def utm_arrivals(days: int) -> int | None:
         token = post_json("/api/auth/login", {"username": user, "password": pw}).get("token")
         if not token:
             return None
-        end = int(datetime.now(timezone.utc).timestamp() * 1000)
+        end = int(datetime.now(UTC).timestamp() * 1000)
         start = end - days * 86400 * 1000
         rows = post_json(
             f"/api/websites/{UMAMI_SITE}/metrics?startAt={start}&endAt={end}&type=query&limit=100",
@@ -347,7 +348,7 @@ def utm_arrivals(days: int) -> int | None:
 
 
 def now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def load_state() -> dict:
@@ -392,7 +393,7 @@ def cmd_check(args) -> int:
     and trips the lander's clean-tree precondition.
     """
     entries = load_ledger()
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=args.stale_hours)
+    cutoff = datetime.now(UTC) - timedelta(hours=args.stale_hours)
     stale = []
     for e in entries:
         if not e.get("packet_sent"):
@@ -401,7 +402,7 @@ def cmd_check(args) -> int:
         try:
             when = datetime.fromisoformat(published)
             if when.tzinfo is None:
-                when = when.replace(tzinfo=timezone.utc)
+                when = when.replace(tzinfo=UTC)
         except ValueError:
             continue
         if when > cutoff:
@@ -461,7 +462,7 @@ def cmd_check(args) -> int:
         high_water = 0
     high_water = max(high_water, 0)
 
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
 
     if count == 0:
         if high_water > 0:


### PR DESCRIPTION
## What
Makes the syndication dead-man check consult UTM traffic before reaching a verdict, and stops it asserting a cause its evidence does not support.

## Why
The guard merged yesterday (#60/#61) reasoned from the ledger alone. On a gap it printed:

> Either the poster is not posting, or replies are not reaching the ingester.

Today that was checked against Umami and found **false**. Since 2026-07-01, startaitools.com received **32 UTM-tagged arrivals**:

| Source | Arrivals |
|---|---|
| LinkedIn | 22 |
| X | 10 |

16 of those carry LinkedIn's own `trk=public_post_comment-text` marker — positive proof the poster is placing the link **in the first comment**, exactly as `02-daily-sop.md` requires. Named campaigns are present too (`evergreen-cad-agent`, `green-recovery-drill`, `deploy-pattern-four-repos`).

**The syndication program is live and being done correctly. Only the reply-to-ledger recording path is missing.** The guard — already wired to cron — would have paged the owner accusing a teammate who is doing the job properly. That is worse than no alarm.

**Chose corroboration over softening the wording** because the wording was only a symptom: the guard was measuring the wrong signal, and a politely-phrased wrong alarm is still a wrong alarm.

## Layer(s) touched
Syndication guard only. No change to produce → land → deploy, no ledger schema change. Adds one **read-only** outbound dependency (Umami REST), explicitly optional.

## How it works
The ledger measures **bookkeeping** (did a reply email arrive). UTM measures **work** (did a reader arrive from a syndicated link). `check` now separates them:

| Ledger | UTM | Verdict | rc |
|---|---|---|---|
| has records | — | healthy | 0 |
| empty | traffic > 0 | recording gap only, syndication live | 0 |
| empty | traffic == 0 | may have stopped — real alarm | 1 (hysteresis) |
| empty | unreachable | degrade to ledger-only, assert no cause | 1 (hysteresis) |

Missing paperwork is a recording gap; missing traffic is an outage. Only the second deserves a page. `--no-utm` forces ledger-only; `--utm-days` sets the window (default 30).

## Verification & evidence
Full regression suite re-run, all prior fixes still hold:
- reply parsing against the SOP's verbatim example (5/5 destinations, personal/company not transposed)
- boundary-anchored canonical matching (`foo` vs `foo-part-2`)
- From-header actor via `parseaddr`
- corrupt and non-object state files (`[]`, `"s"`, `123`, `null`, empty)
- hysteresis ladder 29 → 3 → 10 → 0 returning exactly 1, 0, 1, 3

New UTM verdicts asserted three ways: traffic present → `rc=0` silent; ledger **and** traffic both empty → `rc=1` alarm; Umami unreachable → degrades without crashing.

Live run against the real ledger now returns `rc=0` with *"recording gap only — syndication is demonstrably live"* instead of the false accusation.

## Risk assessment
Low, internal-only. Strictly reduces false alarms; the alarm path for a genuine syndication outage is preserved and now better-founded. Umami is queried read-only with a 15s timeout inside a broad `except` that returns `None`, so an analytics outage degrades the guard rather than breaking it. No public API or contract change.

## Operational impact
- **Deps:** none — `urllib` from stdlib.
- **Secrets:** reads existing `UMAMI_URL`/`UMAMI_USERNAME`/`UMAMI_PASSWORD` from `~/.env`; nothing logged, nothing new provisioned.
- **Network:** one authenticated call per `check` run (daily), against our own analytics host.
- **Migrations/cost/deploy order:** none.

## Rollback
`git revert`, or pass `--no-utm` to restore ledger-only behavior without a deploy.

## Follow-up & deferred
- **`startaitools-v8j`** — the recording path is still one-way: the poster's replies are the only ingest source and none have arrived. Now that UTM confirms the work is happening, the open question is narrowed to *how* completion gets recorded (reply, or attribute from UTM per-post), not *whether* it is happening.
- Owner confirmed the packets are reaching Ezekiel, so the mailbox question from #60 is closed.

## Governance
- Poster SOP: `~/.claude/skills/blog-backfill/references/ezekiel/02-daily-sop.md`
- UTM as the measurement keystone: repo `CLAUDE.md` § "Cross-Posting + Syndication (WS2/WS3)"

Refs #60, #61