### PR TITLE
fix(ci): glob the ruff file list so new scripts cannot merge unlinted

### DIFF
--- a/.github/workflows/scripts-lint.yml
+++ b/.github/workflows/scripts-lint.yml
@@ -56,9 +56,15 @@ jobs:
       - name: ruff check (skill helpers + check-links)
         run: |
           shopt -s globstar nullglob
+          # Glob, do not enumerate. This was an explicit allowlist until
+          # 2026-08-06, so ingest-syndication-replies.py was added in PR #60
+          # and merged twice under a green "ruff" check that had never opened
+          # it; the file in fact carried 7 violations of this repo's own ruff
+          # config. An allowlist silently excludes every new file, which is
+          # the worst property a gate can have: reporting success for work it
+          # did not inspect.
           files=(
-            scripts/blog/catalog-audit.py
-            scripts/blog/reconcile-syndication-state.py
+            scripts/blog/*.py
             .claude/skills/blog-*/scripts/*.py
             check-links.py
           )

--- a/scripts/blog/make-og-base.py
+++ b/scripts/blog/make-og-base.py
@@ -8,8 +8,9 @@ time onto the empty center band (y ~ 200-440). Run once; commit the output.
 
 Output: assets/images/og-base.png (1200x630).
 """
-from PIL import Image, ImageDraw, ImageFont
 import os
+
+from PIL import Image, ImageDraw, ImageFont
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 FONTS = os.path.join(ROOT, "assets", "fonts")

--- a/scripts/blog/next-topics.py
+++ b/scripts/blog/next-topics.py
@@ -43,7 +43,7 @@ import json
 import os
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent.parent  # scripts/blog/ -> repo root
@@ -54,7 +54,7 @@ REQUIRED = ("topic", "slug_hint", "score")
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(UTC).isoformat(timespec="seconds")
 
 
 def _slug(s: str) -> str:
@@ -111,7 +111,7 @@ def cmd_ingest(args) -> int:
     existing = _read(QUEUE)
     open_slugs = {_slug(r.get("slug_hint", "")) for r in existing if r.get("status") == "open"}
 
-    today = datetime.now(timezone.utc).strftime("%Y%m%d")
+    today = datetime.now(UTC).strftime("%Y%m%d")
     seq = 1 + sum(1 for r in existing if r.get("id", "").startswith(f"nt-{today}-"))
 
     added, skipped = [], []
@@ -187,7 +187,8 @@ def cmd_list(args) -> int:
         return 0
     for r in items:
         mark = r.get("status", "open")
-        print(f"{r.get('id','?')}  [{r.get('score','?')} t{r.get('target_tier','?')} {mark}]  {r.get('topic','?')}")
+        print(f"{r.get('id','?')}  [{r.get('score','?')} "
+              f"t{r.get('target_tier','?')} {mark}]  {r.get('topic','?')}")
     return 0
 
 
@@ -232,7 +233,8 @@ def cmd_validate(args) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = ap.add_subparsers(dest="cmd", required=True)
 
     i = sub.add_parser("ingest", help="validate + dedup + append staged candidates")
@@ -245,9 +247,9 @@ def main(argv: list[str] | None = None) -> int:
     t.add_argument("--json", action="store_true", help="emit the full JSON object")
     t.set_defaults(func=cmd_top)
 
-    l = sub.add_parser("list", help="list ranked candidates")
-    l.add_argument("--all", action="store_true", help="include consumed items")
-    l.set_defaults(func=cmd_list)
+    ls = sub.add_parser("list", help="list ranked candidates")
+    ls.add_argument("--all", action="store_true", help="include consumed items")
+    ls.set_defaults(func=cmd_list)
 
     c = sub.add_parser("consume", help="mark an item consumed")
     c.add_argument("item", help="queue id or slug_hint")


### PR DESCRIPTION
## What
Replaces the ruff job's explicit file allowlist with a glob, and fixes the six pre-existing violations that widening the net exposed.

## Why
The ruff job enumerated files by name. Any script added after that list was written was **silently excluded while the check still reported green** — the worst property a gate can have: reporting success for work it never inspected.

Concretely: `scripts/blog/ingest-syndication-replies.py` was added in #60 and merged through **two** PRs under a passing `ruff` check that had never opened it. Run against this repo's own config (`pyproject`: `select = E,F,I,W,UP,B`, line-length 100) it carried **7 violations**.

**Chose globbing over appending the missing filename** because appending fixes today's instance and leaves the mechanism intact; the next new script would be excluded identically.

## Layer(s) touched
CI gate configuration, plus lint-only edits to two pipeline scripts. No behavioural change to the blog pipeline.

## How it works
`files=( scripts/blog/*.py … )` instead of a hand-maintained list. `nullglob` is already set, and the existing empty-array guard still short-circuits cleanly.

Pre-existing violations fixed (none previously linted):
| File | Rule |
|---|---|
| `make-og-base.py` | I001 import ordering |
| `next-topics.py` | UP017 ×2 (`datetime.UTC`, py312 target) |
| `next-topics.py` | E501 ×2 |
| `next-topics.py` | E741 — ambiguous `l` renamed to `ls` |

## Verification & evidence
- `ruff check` over the **full globbed set** (`scripts/blog/*.py` + skill helpers + `check-links.py`) → **All checks passed**.
- `py_compile` clean on both edited files.
- `next-topics.py list` and `next-topics.py --help` both exit 0, proving the E741 rename did not break subparser wiring (that variable binds `cmd_list`).

⚠️ **PR-triggered GitHub Actions are not dispatching on this repo** since 2026-08-05T19:21Z (bead `startaitools-y7i`) — Netlify/Kilo run, `scripts-lint` does not. Push-to-master dispatch still works, so the gate will execute on merge; the local run above is the pre-merge evidence.

## Risk assessment
Low. CI-config plus cosmetic lint fixes. The only semantic edit is the `l` → `ls` rename, which is a local variable in `main()` and is exercised by the two smoke runs above. Strictly increases coverage — it cannot make a passing file fail without that file genuinely violating the repo's own config.

## Operational impact
None. No deps, secrets, migrations, cost, or deploy-order implications. CI job runtime grows marginally with the wider file set.

## Rollback
`git revert`. The gate returns to the allowlist and the lint fixes are harmless on their own.

## Follow-up & deferred
- **`startaitools-y7i`** (P1) — PR-triggered Actions dispatch failure. Repo is public so Actions minutes are free and unmetered, ruling out the 2026-08-01-style billing lock; cause is GitHub-side. Until it resolves, every PR shows green from Netlify alone while its real gates never run.

## Governance
Repo `CLAUDE.md` § "Autonomous Daily Automation"; `pyproject.toml` `[tool.ruff]` is the authority for the ruleset.

Refs #60, #61, #62