### PR TITLE
canary: does a pull_request event dispatch scripts-lint? (DO NOT MERGE)

### DIFF
--- a/scripts/blog/lint-all.sh
+++ b/scripts/blog/lint-all.sh
@@ -83,3 +83,5 @@ else
   printf '\033[31mFAILURES ABOVE\033[0m — do not push; CI runs exactly these.\n'
 fi
 exit "$FAILED"
+
+# canary probe 2026-08-12T20:59:19-06:00: does a pull_request event dispatch scripts-lint?


### PR DESCRIPTION
Diagnostic for `startaitools-y7i`. Zero pull_request-triggered runs since 2026-08-05 while push runs are healthy, and the workflow carries a bare `on: pull_request` on both HEAD and base, so config is not the cause.

This PR exists only to observe whether a real pull_request event dispatches `scripts-lint`. It will be closed unmerged.

Load-bearing because the recommendation worker starts opening PRs on Sunday. If PR dispatch is dead, those PRs arrive showing green Netlify checks with none of the real gates run, which is the green-checks-are-lying failure this blog has written about twice.

- Jeremy Longshore
intentsolutions.io