### PR TITLE
feat(footer): Ko-fi floating support button

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -40,3 +40,28 @@
 {{ if not hugo.IsServer }}
 {{ template "_internal/google_analytics.html" . }}
 {{ end }}
+
+{{/* Ko-fi floating support button.
+
+     Wrapped in the same `not hugo.IsServer` guard the analytics tag uses, so it
+     stays out of `hugo server` and only ships on a real build.
+
+     Colour is orange-700 (#c2410c), not the site's orange-500 (#F97316). The
+     button carries white label text: orange-500 measures 2.80:1 against white
+     and fails WCAG AA, orange-700 measures 5.18:1 and passes. Same hue family,
+     one step darker so the label is legible. Ko-fi's suggested #00b9fe is
+     2.24:1 and was not used. */}}
+{{ if not hugo.IsServer }}
+<script src="https://storage.ko-fi.com/cdn/scripts/overlay-widget.js" defer></script>
+<script>
+  window.addEventListener('load', function () {
+    if (!window.kofiWidgetOverlay) return;
+    kofiWidgetOverlay.draw('jeremylongshore', {
+      'type': 'floating-chat',
+      'floating-chat.donateButton.text': 'Support me',
+      'floating-chat.donateButton.background-color': '#c2410c',
+      'floating-chat.donateButton.text-color': '#fff'
+    });
+  });
+</script>
+{{ end }}


### PR DESCRIPTION
WHAT

  layouts/partials/footer.html   loads Ko-fi's overlay widget on real builds

WHY this shape

Chose the floating overlay over Ko-fi's inline button (Widget_2.js) because it
needs no placement decision in the Archie layout and adds nothing to page flow.

It goes in the existing footer partial, which baseof.html and index.html both
render, so one edit covers the whole site. It reuses the `not hugo.IsServer`
guard already wrapping the analytics tag, so the widget stays out of
`hugo server` and ships only on a real build.

The draw call hangs off `window.onload` with a guard rather than running inline:
the loader is deferred, so an inline call would run during parse and reference
`kofiWidgetOverlay` before it exists.

COLOUR — a contrast decision, not a taste one

The button renders white label text, so its background must clear 4.5:1 against
white. Measured against this site's own palette:

  #00b9fe  Ko-fi's suggested blue   2.24:1   FAIL
  #F97316  orange-500, used here    2.80:1   FAIL
  #ea580c  orange-600               3.56:1   FAIL
  #c2410c  orange-700               5.18:1   PASS  <- used

Same hue family as the site, two steps darker so the label is actually legible.
Using the site's own orange-500 would have shipped a button whose text fails AA.

VERIFICATION

  hugo --gc --minify --cleanDestinationDir   -> built, 88 static files, 757 images
  grep kofiWidgetOverlay public/index.html   -> 1 (present in output)
  grep background-color public/index.html    -> "#c2410c" (correct colour shipped)

RISK

User-facing and site-wide: it renders on every page. Third-party script from
storage.ko-fi.com, loaded deferred, so it does not block first paint. Its styling
is outside the site's CSS and cannot be themed further, and it does not honour
prefers-reduced-motion — neither is controllable from here. Rollback is deleting
the block from the footer partial.

OPERATIONAL IMPACT

None. No env vars, no secrets, no dependencies, no build-step change. Netlify
deploys `master`; this is on a branch so nothing reaches production until merge.

UNFINISHED

ko-fi.com/U5S225PTME returns 403 to curl from this host even with a browser user
agent, which reads as bot protection on a datacenter IP rather than a bad link.
Not positively confirmed from this machine — worth one click in a browser.

- Jeremy Longshore
intentsolutions.io